### PR TITLE
Added the branch alias and changed the constraint on common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,14 @@
         "php": ">=5.3.0"
     },
     "require-dev" : {
-        "doctrine/common" : "2.0.*"
+        "doctrine/common" : ">=2.0,<2.4-dev"
     },
     "autoload": {
         "psr-0": { "Metadata\\": "src/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.2.x-dev"
+        }
     }
 }


### PR DESCRIPTION
The branch alias allows other packages to depend on `1.2.*` if they need the new features which are not part of 1.1 instead of having to use an unbound constraint (which forbids them to tag a release)
