### PR TITLE
Advanced metadata implementation.

### DIFF
--- a/src/Metadata/AdvancedMetadataFactoryInterface.php
+++ b/src/Metadata/AdvancedMetadataFactoryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Metadata;
+
+/**
+ * Interface for advanced Metadata Factory implementations.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Jordan Stout <j@jrdn.org>
+ */
+interface AdvancedMetadataFactoryInterface extends MetadataFactoryInterface
+{
+    /**
+     * Gets all the possible classes.
+     *
+     * @throws \RuntimeException if driver does not an advanced driver.
+     * @return array
+     */
+    public function getAllClassNames();
+}

--- a/src/Metadata/Driver/AbstractFileDriver.php
+++ b/src/Metadata/Driver/AbstractFileDriver.php
@@ -7,8 +7,11 @@ namespace Metadata\Driver;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-abstract class AbstractFileDriver implements DriverInterface
+abstract class AbstractFileDriver implements AdvancedDriverInterface
 {
+    /**
+     * @var FileLocatorInterface|FileLocator
+     */
     private $locator;
 
     public function __construct(FileLocatorInterface $locator)
@@ -23,6 +26,18 @@ abstract class AbstractFileDriver implements DriverInterface
         }
 
         return $this->loadMetadataFromFile($class, $path);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAllClassNames()
+    {
+        if (!$this->locator instanceof AdvancedFileLocatorInterface) {
+            throw new \RuntimeException('Locator "%s" must be an instance of "AdvancedFileLocatorInterface".');
+        }
+
+        return $this->locator->findAllClasses($this->getExtension());
     }
 
     /**

--- a/src/Metadata/Driver/AdvancedDriverInterface.php
+++ b/src/Metadata/Driver/AdvancedDriverInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Metadata\Driver;
+
+/**
+ * Forces advanced logic to drivers.
+ *
+ * @author Jordan Stout <j@jrdn.org>
+ */
+interface AdvancedDriverInterface extends DriverInterface
+{
+    /**
+     * Gets all the metadata class names known to this driver.
+     *
+     * @return array
+     */
+    public function getAllClassNames();
+}

--- a/src/Metadata/Driver/AdvancedFileLocatorInterface.php
+++ b/src/Metadata/Driver/AdvancedFileLocatorInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright 2011 Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Metadata\Driver;
+
+/**
+ * Forces advanced logic on a file locator.
+ *
+ * @author Jordan Stout <j@jrdn.org>
+ */
+interface AdvancedFileLocatorInterface extends FileLocatorInterface
+{
+    /**
+     * Finds all possible metadata files.
+     *
+     * @param string $extension
+     *
+     * @return array
+     */
+    public function findAllClasses($extension);
+}

--- a/src/Metadata/Driver/DriverChain.php
+++ b/src/Metadata/Driver/DriverChain.php
@@ -18,7 +18,7 @@
 
 namespace Metadata\Driver;
 
-final class DriverChain implements DriverInterface
+final class DriverChain implements AdvancedDriverInterface
 {
     private $drivers;
 
@@ -36,5 +36,30 @@ final class DriverChain implements DriverInterface
         }
 
         return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAllClassNames()
+    {
+        $classes = array();
+        foreach ($this->drivers as $driver) {
+            if (!$driver instanceof AdvancedDriverInterface) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'Driver "%s" must be an instance of "AdvancedDriverInterface" to use '.
+                        '"DriverChain::getAllClassNames()".',
+                        get_class($driver)
+                    )
+                );
+            }
+            $driverClasses = $driver->getAllClassNames();
+            if (!empty($driverClasses)) {
+                $classes = array_merge($classes, $driverClasses);
+            }
+        }
+
+        return $classes;
     }
 }

--- a/src/Metadata/Driver/FileLocator.php
+++ b/src/Metadata/Driver/FileLocator.php
@@ -2,7 +2,7 @@
 
 namespace Metadata\Driver;
 
-class FileLocator implements FileLocatorInterface
+class FileLocator implements AdvancedFileLocatorInterface
 {
     private $dirs;
 
@@ -34,5 +34,29 @@ class FileLocator implements FileLocatorInterface
         }
 
         return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findAllClasses($extension)
+    {
+        $classes = array();
+        foreach ($this->dirs as $prefix => $dir) {
+            /** @var $iterator \RecursiveIteratorIterator|\SplFileInfo[] */
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($dir),
+                \RecursiveIteratorIterator::LEAVES_ONLY
+            );
+            foreach ($iterator as $file) {
+                if (($fileName = $file->getBasename('.'.$extension)) == $file->getBasename()) {
+                    continue;
+                }
+
+                $classes[] = ($prefix !== '' ? $prefix.'\\' : '').str_replace('.', '\\', $fileName);
+            }
+        }
+
+        return $classes;
     }
 }

--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -18,10 +18,11 @@
 
 namespace Metadata;
 
+use Metadata\Driver\AdvancedDriverInterface;
 use Metadata\Driver\DriverInterface;
 use Metadata\Cache\CacheInterface;
 
-final class MetadataFactory implements MetadataFactoryInterface
+final class MetadataFactory implements AdvancedMetadataFactoryInterface
 {
     private $driver;
     private $cache;
@@ -96,6 +97,20 @@ final class MetadataFactory implements MetadataFactoryInterface
         }
 
         return $this->loadedMetadata[$className] = $metadata;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAllClassNames()
+    {
+        if (!$this->driver instanceof AdvancedDriverInterface) {
+            throw new \RuntimeException(
+                sprintf('Driver "%s" must be an instance of "AdvancedDriverInterface".', get_class($this->driver))
+            );
+        }
+
+        return $this->driver->getAllClassNames();
     }
 
     /**

--- a/tests/Metadata/Tests/Driver/AbstractFileDriverTest.php
+++ b/tests/Metadata/Tests/Driver/AbstractFileDriverTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Metadata\Tests\Driver;
+
+use Metadata\ClassMetadata;
+
+/**
+ * @author Jordan Stout <j@jrdn.org>
+ */
+class AbstractFileDriverTest extends \PHPUnit_Framework_TestCase
+{
+    private static $extension = 'jms_metadata.yml';
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    private $locator;
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    private $driver;
+
+    public function setUp()
+    {
+        $this->locator = $this->getMock('Metadata\Driver\FileLocator', array(), array(), '', false);
+        $this->driver = $this->getMockBuilder('Metadata\Driver\AbstractFileDriver')
+            ->setConstructorArgs(array($this->locator))
+            ->getMockForAbstractClass();
+
+        $this->driver->expects($this->any())->method('getExtension')->will($this->returnValue(self::$extension));
+    }
+
+    public function testLoadMetadataForClass()
+    {
+        $class = new \ReflectionClass('\stdClass');
+        $this->locator
+            ->expects($this->once())
+            ->method('findFileForClass')
+            ->with($class, self::$extension)
+            ->will($this->returnValue('Some\Path'));
+
+        $this->driver
+            ->expects($this->once())
+            ->method('loadMetadataFromFile')
+            ->with($class, 'Some\Path')
+            ->will($this->returnValue($metadata = new ClassMetadata('\stdClass')));
+
+        $this->assertSame($metadata, $this->driver->loadMetadataForClass($class));
+    }
+
+    public function testLoadMetadataForClassWillReturnNull()
+    {
+        $class = new \ReflectionClass('\stdClass');
+        $this->locator
+            ->expects($this->once())
+            ->method('findFileForClass')
+            ->with($class, self::$extension)
+            ->will($this->returnValue(null));
+
+        $this->assertSame(null, $this->driver->loadMetadataForClass($class));
+    }
+
+    public function testGetAllClassNames()
+    {
+        $class = new \ReflectionClass('\stdClass');
+        $this->locator
+            ->expects($this->once())
+            ->method('findAllClasses')
+            ->with(self::$extension)
+            ->will($this->returnValue(array('\stdClass')));
+
+        $this->assertSame(array('\stdClass'), $this->driver->getAllClassNames($class));
+    }
+
+    public function testGetAllClassNamesThrowsRuntimeException()
+    {
+        $this->setExpectedException('RuntimeException');
+
+        $locator = $this->getMock('Metadata\Driver\FileLocatorInterface', array(), array(), '', false);
+        $driver = $this->getMockBuilder('Metadata\Driver\AbstractFileDriver')
+            ->setConstructorArgs(array($locator))
+            ->getMockForAbstractClass();
+        $class = new \ReflectionClass('\stdClass');
+        $locator->expects($this->never())->method('findAllClasses');
+
+        $driver->getAllClassNames($class);
+    }
+}

--- a/tests/Metadata/Tests/Driver/DriverChainTest.php
+++ b/tests/Metadata/Tests/Driver/DriverChainTest.php
@@ -20,6 +20,25 @@ class DriverChainTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($metadata, $chain->loadMetadataForClass(new \ReflectionClass('\stdClass')));
     }
 
+    public function testGetAllClassNames()
+    {
+        $driver1 = $this->getMock('Metadata\\Driver\\AdvancedDriverInterface');
+        $driver1
+            ->expects($this->once())
+            ->method('getAllClassNames')
+            ->will($this->returnValue(array('Foo')));
+
+        $driver2 = $this->getMock('Metadata\\Driver\\AdvancedDriverInterface');
+        $driver2
+            ->expects($this->once())
+            ->method('getAllClassNames')
+            ->will($this->returnValue(array('Bar')));
+
+        $chain = new DriverChain(array($driver1, $driver2));
+
+        $this->assertSame(array('Foo', 'Bar'), $chain->getAllClassNames());
+    }
+
     public function testLoadMetadataForClassReturnsNullWhenNoMetadataIsFound()
     {
         $driver = new DriverChain(array());
@@ -33,5 +52,14 @@ class DriverChainTest extends \PHPUnit_Framework_TestCase
         ;
         $driverChain = new DriverChain(array($driver));
         $this->assertNull($driver->loadMetadataForClass(new \ReflectionClass('\stdClass')));
+    }
+
+    public function testGetAllClassNamesThrowsException()
+    {
+        $this->setExpectedException('RuntimeException');
+        $driver = $this->getMock('Metadata\\Driver\\DriverInterface');
+        $driver->expects($this->never())->method('getAllClassNames');
+        $chain = new DriverChain(array($driver));
+        $chain->getAllClassNames();
     }
 }

--- a/tests/Metadata/Tests/Driver/FileLocatorTest.php
+++ b/tests/Metadata/Tests/Driver/FileLocatorTest.php
@@ -48,4 +48,22 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
         $ref = new \ReflectionClass('D');
         $this->assertEquals(realpath(__DIR__.'/Fixture/D/D.yml'), realpath($locator->findFileForClass($ref, 'yml')));
     }
+
+    public function testFindAllFiles()
+    {
+        $locator = new FileLocator(array(
+            'Metadata\Tests\Driver\Fixture\A' => __DIR__.'/Fixture/A',
+            'Metadata\Tests\Driver\Fixture\B' => __DIR__.'/Fixture/B',
+            'Metadata\Tests\Driver\Fixture\C' => __DIR__.'/Fixture/C',
+            'Metadata\Tests\Driver\Fixture\D' => __DIR__.'/Fixture/D'
+        ));
+
+        $this->assertCount(1, $xmlFiles = $locator->findAllClasses('xml'));
+        $this->assertSame('Metadata\Tests\Driver\Fixture\A\A', $xmlFiles[0]);
+
+        $this->assertCount(3, $ymlFiles = $locator->findAllClasses('yml'));
+        $this->assertSame('Metadata\Tests\Driver\Fixture\B\B', $ymlFiles[0]);
+        $this->assertSame('Metadata\Tests\Driver\Fixture\C\SubDir\C', $ymlFiles[1]);
+        $this->assertSame('Metadata\Tests\Driver\Fixture\D\D', $ymlFiles[2]);
+    }
 }

--- a/tests/Metadata/Tests/MetadataFactoryTest.php
+++ b/tests/Metadata/Tests/MetadataFactoryTest.php
@@ -3,9 +3,7 @@
 namespace Metadata\Tests;
 
 use Metadata\PropertyMetadata;
-
 use Metadata\MergeableClassMetadata;
-
 use Metadata\ClassMetadata;
 use Metadata\MetadataFactory;
 
@@ -180,5 +178,24 @@ class MetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $factory->setIncludeInterfaces(true);
 
         $factory->getMetadataForClass('Metadata\Tests\Fixtures\ComplexHierarchy\SubClassA');
+    }
+
+    public function testGetAllClassNames()
+    {
+        $driver = $this->getMock('Metadata\Driver\AdvancedDriverInterface');
+        $driver
+            ->expects($this->once())
+            ->method('getAllClassNames')
+            ->will($this->returnValue(array()));
+
+        $factory = new MetadataFactory($driver);
+        $this->assertSame(array(), $factory->getAllClassNames());
+    }
+
+    public function testGetAllClassNamesThrowsException()
+    {
+        $this->setExpectedException('RuntimeException');
+        $factory = new MetadataFactory($this->getMock('Metadata\Driver\DriverInterface'));
+        $factory->getAllClassNames();
     }
 }


### PR DESCRIPTION
Fixes #19

Before I head to a holiday work party, I wanted to push what I've got so far, only because I have a few questions pertaining to it.

I was crunching it all together just to get it done real fast.

In this attempt, I was going to make it up to the driver to return the class name, but once I got to the FileDriver, and after looking at the old ones, it looks as if metadata files need to be named according to the class it pertains to (with or without the prefix).  Which makes me feel that instead of just returning all files that match for the driver, to instead parse suggested class names from the file name / prefix known to the driver.

What do you think @schmittjoh ?

We can then talk about if we should put a warmupCache method or something in the abstract driver to actually cache metadata and such.

None-the-less, this should be a step in a positive direction as far as this library is concerned I'd say.

I'll add the rest of the tests when I know I'm heading in the right direction.  I added one showing the finders functionality before i change it.

Happy holidays!
