### PR TITLE
Get the cache from metadata factory

### DIFF
--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -52,9 +52,20 @@ final class MetadataFactory implements AdvancedMetadataFactoryInterface
         $this->includeInterfaces = (Boolean) $include;
     }
 
+    /**
+     * @param CacheInterface $cache
+     */
     public function setCache(CacheInterface $cache)
     {
         $this->cache = $cache;
+    }
+    
+    /**
+     * @return CacheInterface
+     */
+    public function getCache()
+    {
+        return $this->cache;
     }
 
     /**


### PR DESCRIPTION
I need to clear the cache from a CLI tool, not being able to access the cache from the MetadataFactory is a bit annoying. I think we should be able to access it.
