### PR TITLE
Avoid a race condition that can occur when writing cache files

### DIFF
--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -77,7 +77,8 @@ final class MetadataFactory implements AdvancedMetadataFactoryInterface
 
             // check the cache
             if (null !== $this->cache
-                && (null !== $classMetadata = $this->cache->loadClassMetadataFromCache($class))) {
+                && (null !== $classMetadata = $this->cache->loadClassMetadataFromCache($class))
+                && $classMetadata instanceof ClassMetadata) {
                 if ($this->debug && !$classMetadata->isFresh()) {
                     $this->cache->evictClassMetadataFromCache($classMetadata->reflection);
                 } else {


### PR DESCRIPTION
file_put_contents() is used in putClassMetadataInCache(), which does not write files atomically so I added a check here to make sure we get an appropriate class object before blindly calling methods on it. Alternatively you could use an atomic write command and avoid this issue entirely.
