### PR TITLE
Allow to add drivers to a driver chain

### DIFF
--- a/src/Metadata/Driver/DriverChain.php
+++ b/src/Metadata/Driver/DriverChain.php
@@ -22,9 +22,14 @@ final class DriverChain implements AdvancedDriverInterface
 {
     private $drivers;
 
-    public function __construct(array $drivers)
+    public function __construct(array $drivers = array())
     {
         $this->drivers = $drivers;
+    }
+    
+    public function addDriver(DriverInterface $driver)
+    {
+        $this->drivers[] = $driver;
     }
 
     public function loadMetadataForClass(\ReflectionClass $class)


### PR DESCRIPTION
In my specific case, each driver needs to have a reference to the metadata factory, and to create the metadata factory I need... the driver chain. So I'm stuck. Adding this method add a bit of flexibility to the DriverChain.
