### PR TITLE
Cache when there is no metadata for a class

### DIFF
--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -65,28 +65,37 @@ final class MetadataFactory implements AdvancedMetadataFactoryInterface
     public function getMetadataForClass($className)
     {
         if (isset($this->loadedMetadata[$className])) {
-            return $this->loadedMetadata[$className];
+            return $this->filterNullMetadata($this->loadedMetadata[$className]);
         }
 
         $metadata = null;
         foreach ($this->getClassHierarchy($className) as $class) {
             if (isset($this->loadedClassMetadata[$name = $class->getName()])) {
-                $this->addClassMetadata($metadata, $this->loadedClassMetadata[$name]);
+                if (null !== $classMetadata = $this->filterNullMetadata($this->loadedClassMetadata[$name])) {
+                    $this->addClassMetadata($metadata, $classMetadata);
+                }
                 continue;
             }
 
             // check the cache
-            if (null !== $this->cache && (null !== $classMetadata = $this->cache->loadClassMetadataFromCache($class))) {
-                if ( ! $classMetadata instanceof ClassMetadata) {
-                    throw new \LogicException(sprintf('The cache must return instances of ClassMetadata, but got %s.', var_export($classMetadata, true)));
+            if (null !== $this->cache) {
+                if (($classMetadata = $this->cache->loadClassMetadataFromCache($class)) instanceof NullMetadata) {
+                    $this->loadedClassMetadata[$name] = $classMetadata;
+                    continue;
                 }
 
-                if ($this->debug && !$classMetadata->isFresh()) {
-                    $this->cache->evictClassMetadataFromCache($classMetadata->reflection);
-                } else {
-                    $this->loadedClassMetadata[$name] = $classMetadata;
-                    $this->addClassMetadata($metadata, $classMetadata);
-                    continue;
+                if (null !== $classMetadata) {
+                    if ( ! $classMetadata instanceof ClassMetadata) {
+                        throw new \LogicException(sprintf('The cache must return instances of ClassMetadata, but got %s.', var_export($classMetadata, true)));
+                    }
+
+                    if ($this->debug && !$classMetadata->isFresh()) {
+                        $this->cache->evictClassMetadataFromCache($classMetadata->reflection);
+                    } else {
+                        $this->loadedClassMetadata[$name] = $classMetadata;
+                        $this->addClassMetadata($metadata, $classMetadata);
+                        continue;
+                    }
                 }
             }
 
@@ -101,9 +110,17 @@ final class MetadataFactory implements AdvancedMetadataFactoryInterface
 
                 continue;
             }
+
+            if (null !== $this->cache && !$this->debug) {
+                $this->cache->putClassMetadataInCache(new NullMetadata());
+            }
         }
 
-        return $this->loadedMetadata[$className] = $metadata;
+        if (null === $metadata) {
+            $metadata = new NullMetadata();
+        }
+
+        return $this->filterNullMetadata($this->loadedMetadata[$className] = $metadata);
     }
 
     /**
@@ -174,5 +191,10 @@ final class MetadataFactory implements AdvancedMetadataFactoryInterface
         }
 
         return $newHierarchy;
+    }
+
+    private function filterNullMetadata($metadata = null)
+    {
+        return !$metadata instanceof NullMetadata ? $metadata : null;
     }
 }

--- a/src/Metadata/NullMetadata.php
+++ b/src/Metadata/NullMetadata.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Metadata;
+
+/**
+ * Represents the metadata for a class that has not metadata.
+ *
+ * @author Adrien Brault <adrien.brault@gmail.com>
+ */
+class NullMetadata extends ClassMetadata
+{
+    public function __construct()
+    {
+
+    }
+
+    public function serialize()
+    {
+        return '';
+    }
+
+    public function unserialize($str)
+    {
+
+    }
+}


### PR DESCRIPTION
What this changes:
- In debug, the factory will try to load the metadata of a class only once (per request) if there is none, instead of multiple times
- In debug=false, the factory will try to load the metadata of a class only once until the cache is cleared (among multiple requests)

There should be way less `file_exists` going on :)
