### PR TITLE
Update FileCache.php added fallback option when rename fails on windows

### DIFF
--- a/src/Metadata/Cache/FileCache.php
+++ b/src/Metadata/Cache/FileCache.php
@@ -44,16 +44,26 @@ class FileCache implements CacheInterface
         file_put_contents($tmpFile, '<?php return unserialize('.var_export(serialize($metadata), true).');');
         chmod($tmpFile, 0666 & ~umask());
 
-        if (false === @rename($tmpFile, $path)) {
-            if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-                if (false === unlink($path)) {
-                    throw new \RuntimeException(sprintf('(WIN) Could not delete temp cache file to %s.', $path));
+        $this->renameFile($tmpFile, $path);
+    }
+
+    /**
+     * Renames a file with fallback for windows
+     *
+     * @param string $oldname
+     * @param string $newname
+     */
+    private function renameFile($oldname, $newname) {
+        if (false === @rename($oldname, $newname)) {
+            if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+                if (false === unlink($newname)) {
+                    throw new \RuntimeException(sprintf('(WIN) Could not delete temp cache file to %s.', $newname));
                 }
-                if (false === copy($tmpFile, $path)) {
-                    throw new \RuntimeException(sprintf('(WIN) Could not write new cache file to %s.', $path));
+                if (false === copy($oldname, $newname)) {
+                    throw new \RuntimeException(sprintf('(WIN) Could not write new cache file to %s.', $newname));
                 }
             } else {
-                throw new \RuntimeException(sprintf('Could not write new cache file to %s.', $path));
+                throw new \RuntimeException(sprintf('Could not write new cache file to %s.', $newname));
             }
         }
     }


### PR DESCRIPTION
Under, unfortunately unknown, circumstances rename() does not work properly under windows when the target file exists. See also this comment http://us2.php.net/manual/en/function.rename.php#60341 

When testing and removing the @ in front of rename() the following occured:

PHP Warning:  rename(C:\inetpub\symfony\app\cache\prod\jms_diextra\metadata\met666B.tmp,C:/inetpub/symfony/app/cache/prod/jms_diextra/metadata/.cache.php): Access is denied. (code: 5) in C:\inetpub\symfony\vendor\jms\metadata\src\Metadata\Cache\FileCache.php on line 98

This is a patch to fix the problem for the windows platform. Like the comment describes the function will no longer be atomic (rename vs unlink+copy). But it seems to be the best solution available.

Sometimes it happens, sometimes it doesn't, i'm afraid i can't pinpoint the exact cause without diving into PHP internals and C.

The problem was found investigating this issue https://github.com/schmittjoh/metadata/issues/39
