### PR TITLE
Fix NullMetadata performance issue

### DIFF
--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -112,12 +112,12 @@ class MetadataFactory implements AdvancedMetadataFactoryInterface
             }
 
             if (null !== $this->cache && !$this->debug) {
-                $this->cache->putClassMetadataInCache(new NullMetadata());
+                $this->cache->putClassMetadataInCache(new NullMetadata($class->getName()));
             }
         }
 
         if (null === $metadata) {
-            $metadata = new NullMetadata();
+            $metadata = new NullMetadata($className);
         }
 
         return $this->filterNullMetadata($this->loadedMetadata[$className] = $metadata);

--- a/src/Metadata/NullMetadata.php
+++ b/src/Metadata/NullMetadata.php
@@ -9,18 +9,5 @@ namespace Metadata;
  */
 class NullMetadata extends ClassMetadata
 {
-    public function __construct()
-    {
 
-    }
-
-    public function serialize()
-    {
-        return '';
-    }
-
-    public function unserialize($str)
-    {
-
-    }
 }


### PR DESCRIPTION
cc #44 #45

@sdepablos @luxemate Can you guys try that fix ?

I was able to confirm that the `NullMetadata::serialize` method was called even though those cache files were supposed to already exist. With that fix, `ClassMetadata::serialize` is not called anymore once the cache is created.

On my test endpoint, the response time (prod env, cache warmed) went down from 305ms to 275ms with that fix (simple `ab -n 100 -c 1`).
