### PR TITLE
Make the class hierarchy discovery protected

### DIFF
--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -24,12 +24,13 @@ use Metadata\Cache\CacheInterface;
 
 class MetadataFactory implements AdvancedMetadataFactoryInterface
 {
+    protected $includeInterfaces = false;
+
     private $driver;
     private $cache;
     private $loadedMetadata = array();
     private $loadedClassMetadata = array();
     private $hierarchyMetadataClass;
-    private $includeInterfaces = false;
     private $debug;
 
     /**
@@ -160,8 +161,9 @@ class MetadataFactory implements AdvancedMetadataFactoryInterface
 
     /**
      * @param string $class
+     * @return array<string>
      */
-    private function getClassHierarchy($class)
+    protected function getClassHierarchy($class)
     {
         $classes = array();
         $refl = new \ReflectionClass($class);


### PR DESCRIPTION
This allows subclasses to extend/override the behaviour when finding a class hierarchy from a class name, without reimplementing `getMetadataForClass()`.

This doesn't necessarily imply these methods are part of a stable API - you might use something like Symfony's `@api` to do so in the future, if you want to make it clear that protected APIs aren't considered part of the stable API. ([This](http://fabien.potencier.org/pragmatism-over-theory-protected-vs-private.html) is a nice description of that approach.)

This is one way to fix #54 
