### PR TITLE
Catch exceptions when unserializing from cache

### DIFF
--- a/src/Metadata/MetadataFactory.php
+++ b/src/Metadata/MetadataFactory.php
@@ -79,9 +79,14 @@ class MetadataFactory implements AdvancedMetadataFactoryInterface
 
             // check the cache
             if (null !== $this->cache) {
-                if (($classMetadata = $this->cache->loadClassMetadataFromCache($class)) instanceof NullMetadata) {
-                    $this->loadedClassMetadata[$name] = $classMetadata;
-                    continue;
+                try {
+                    if (($classMetadata = $this->cache->loadClassMetadataFromCache($class)) instanceof NullMetadata) {
+                        $this->loadedClassMetadata[$name] = $classMetadata;
+                        continue;
+                    }
+                } catch (\ReflectionException $e) {
+                    // error during unserialze
+                    $classMetadata = null;
                 }
 
                 if (null !== $classMetadata) {

--- a/tests/Metadata/Tests/MetadataFactoryTest.php
+++ b/tests/Metadata/Tests/MetadataFactoryTest.php
@@ -276,4 +276,28 @@ class MetadataFactoryTest extends \PHPUnit_Framework_TestCase
         $factory->getMetadataForClass('Metadata\Tests\Fixtures\TestObject');
         $this->assertNull($factory->getMetadataForClass('Metadata\Tests\Fixtures\TestObject'));
     }
+
+    public function testLoadingCorruptMetadataFromCacheLoadsUsingDriver()
+    {
+        $driver = $this->getMock('Metadata\Driver\DriverInterface');
+        $driver
+            ->expects($this->exactly(1))
+            ->method('loadMetadataForClass')
+            ->will($this->returnValue(null))
+        ;
+
+        $cachedMetadata = null;
+        $cache = $this->getMock('Metadata\Cache\CacheInterface');
+        $cache
+            ->expects($this->once())
+            ->method('loadClassMetadataFromCache')
+            ->with($this->equalTo(new \ReflectionClass('Metadata\Tests\Fixtures\TestObject')))
+            ->will($this->throwException(new \ReflectionException()))
+        ;
+
+        $factory = new MetadataFactory($driver, 'Metadata\ClassHierarchyMetadata', true);
+        $factory->setCache($cache);
+        $factory->getMetadataForClass('Metadata\Tests\Fixtures\TestObject');
+        $this->assertNull($factory->getMetadataForClass('Metadata\Tests\Fixtures\TestObject'));
+    }
 }


### PR DESCRIPTION
wrap loading metadata from cache in try-catch to catch exceptions during deserialization - fixes #59
