### PR TITLE
Do not create MethodMetadata::$reflection on constructor/unserialize,…

### DIFF
--- a/tests/MethodMetadataTest.php
+++ b/tests/MethodMetadataTest.php
@@ -6,6 +6,7 @@ namespace Metadata\Tests;
 
 use Metadata\MethodMetadata;
 use Metadata\Tests\Fixtures\TestObject;
+use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\TestCase;
 
 class MethodMetadataTest extends TestCase
@@ -36,5 +37,66 @@ class MethodMetadataTest extends TestCase
         $this->assertNull($obj->getFoo());
         $metadata->invoke($obj, ['foo']);
         $this->assertEquals('foo', $obj->getFoo());
+    }
+
+    public function testLazyReflectionCreationOnConstruction()
+    {
+        $metadata = new MethodMetadata(TestObject::class, 'setFoo');
+
+        $reflectionProperty = new \ReflectionProperty(MethodMetadata::class, 'reflection');
+        $reflectionProperty->setAccessible(true);
+
+        $this->assertNull($reflectionProperty->getValue($metadata));
+    }
+
+    public function testLazyReflectionCreationOnUnserialize()
+    {
+        $metadata = new MethodMetadata(TestObject::class, 'setFoo');
+        $metadataUnserialized = unserialize(serialize($metadata));
+
+        $reflectionProperty = new \ReflectionProperty(MethodMetadata::class, 'reflection');
+        $reflectionProperty->setAccessible(true);
+
+        $this->assertNull($reflectionProperty->getValue($metadata));
+    }
+
+    public function testReflectionReadAccessReturnsSameInstance()
+    {
+        $metadata = new MethodMetadata(TestObject::class, 'setFoo');
+
+        $reflection1 = $metadata->reflection;
+        $reflection2 = $metadata->reflection;
+
+        $this->assertInstanceOf(\ReflectionMethod::class, $reflection1);
+        $this->assertSame($reflection1, $reflection2);
+    }
+
+    public function testReflectionWriteAccess()
+    {
+        $metadata = new MethodMetadata(TestObject::class, 'setFoo');
+
+        $otherValue = 'test';
+        $metadata->reflection = $otherValue;
+
+        $this->assertSame($otherValue, $metadata->reflection);
+    }
+
+    public function testReadAccessForUnknownProperty()
+    {
+        $metadata = new MethodMetadata(TestObject::class, 'setFoo');
+
+        $this->expectException(Notice::class);
+        $this->expectExceptionMessage('Undefined property: Metadata\MethodMetadata::$unknownProperty');
+
+        $metadata->unknownProperty;
+    }
+
+    public function testWriteAccessForUnknownProperty()
+    {
+        $metadata = new MethodMetadata(TestObject::class, 'setFoo');
+
+        $metadata->unknownProperty = 'some value';
+
+        $this->assertSame('some value', $metadata->unknownProperty);
     }
 }

--- a/tests/MethodMetadataTest.php
+++ b/tests/MethodMetadataTest.php
@@ -75,7 +75,7 @@ class MethodMetadataTest extends TestCase
     {
         $metadata = new MethodMetadata(TestObject::class, 'setFoo');
 
-        $otherValue = 'test';
+        $otherValue = new \ReflectionMethod(TestObject::class, 'getFoo');
         $metadata->reflection = $otherValue;
 
         $this->assertSame($otherValue, $metadata->reflection);


### PR DESCRIPTION
… but on first usage.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #77
| License       | MIT

