### PR TITLE
Handle errors when restoring from cache

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -32,7 +32,17 @@ class FileCache implements CacheInterface
             return null;
         }
 
-        return include $path;
+        try {
+            $metadata = include $path;
+            if ($metadata instanceof ClassMetadata) {
+                return $metadata;
+            }
+            // if the file does not return anything, the return value is integer `1`.
+        } catch (\ParseError $e) {
+            // ignore corrupted cache
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -35,4 +35,22 @@ class FileCacheTest extends TestCase
         $cache->evict(TestObject::class);
         $this->assertNull($cache->load(TestObject::class));
     }
+
+    public function provideCorruptedCache()
+    {
+        yield 'No return statement' => ['<?php $a = "foo";'];
+        yield 'Syntax error' => ['<?php syntax error'];
+    }
+
+    /**
+     * @dataProvider provideCorruptedCache
+     */
+    public function testNonReturningCache(string $fileContents)
+    {
+        $cache = new FileCache($this->dir);
+
+        file_put_contents($this->dir.'/Metadata-Tests-Fixtures-TestObject.cache.php', $fileContents);
+
+        $this->assertNull($cache->load(TestObject::class));
+    }
 }


### PR DESCRIPTION
If the cache file became garbled for some reason, this should not break anything.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

See also #82 where i try to prevent us from writing corrupt caches.