### PR TITLE
make sure we only use the cache if write was successful

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -48,6 +48,8 @@ class FileCache implements CacheInterface
 
         $tmpFile = tempnam($this->dir, 'metadata-cache');
         if (false === $tmpFile) {
+            $this->evict($metadata->name);
+
             return;
         }
         $data = '<?php return unserialize(' . var_export(serialize($metadata), true) . ');';

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -47,7 +47,18 @@ class FileCache implements CacheInterface
         $path = $this->dir . '/' . strtr($metadata->name, '\\', '-') . '.cache.php';
 
         $tmpFile = tempnam($this->dir, 'metadata-cache');
-        file_put_contents($tmpFile, '<?php return unserialize(' . var_export(serialize($metadata), true) . ');');
+        if (false === $tmpFile) {
+            return;
+        }
+        $data = '<?php return unserialize(' . var_export(serialize($metadata), true) . ');';
+        $bytesWritten = file_put_contents($tmpFile, $data);
+        // use strlen and not mb_strlen. if there is utf8 in the code, it also writes more bytes.
+        if ($bytesWritten !== strlen($data)) {
+            @unlink($tmpFile);
+            $this->evict($metadata->name); // also evict the cache to not use an outdated version.
+
+            return;
+        }
 
         // Let's not break filesystems which do not support chmod.
         @chmod($tmpFile, 0666 & ~umask());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

I don't know how to test this, as those things normally don't fail. (Most likely offender would be out of disk space...). But i did validate with a 😃 in the TestObject that utf8 in code does not break the strlen vs bytes written.

See also #81 for when the data already is written or a disk is corrupted later on.