### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
         - php: 7.2
         - php: 7.2
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+        - php: 7.3
     fast_finish: true
 
 before_script:
@@ -29,5 +30,3 @@ script:
 after_success:
     - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
     - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then php ocular.phar code-coverage:upload --format=php-clover clover; fi
-
-

--- a/src/MetadataFactory.php
+++ b/src/MetadataFactory.php
@@ -154,7 +154,8 @@ class MetadataFactory implements AdvancedMetadataFactoryInterface
             }
         } else {
             if (null === $metadata) {
-                $metadata = new $this->hierarchyMetadataClass();
+                $class = $this->hierarchyMetadataClass;
+                $metadata = new $class();
             }
 
             $metadata->addClassMetadata($toAdd);

--- a/tests/Cache/DoctrineCacheAdapterTest.php
+++ b/tests/Cache/DoctrineCacheAdapterTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 class DoctrineCacheAdapterTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         if (!interface_exists('Doctrine\Common\Cache\Cache')) {
             $this->markTestSkipped('Doctrine\Common is not installed.');

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -13,7 +13,7 @@ class FileCacheTest extends TestCase
 {
     private $dir;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->dir = sys_get_temp_dir() . '/jms-' . md5(__CLASS__);
         if (is_dir($this->dir)) {
@@ -49,7 +49,7 @@ class FileCacheTest extends TestCase
     {
         $cache = new FileCache($this->dir);
 
-        file_put_contents($this->dir.'/Metadata-Tests-Fixtures-TestObject.cache.php', $fileContents);
+        file_put_contents($this->dir . '/Metadata-Tests-Fixtures-TestObject.cache.php', $fileContents);
 
         $this->assertNull($cache->load(TestObject::class));
     }

--- a/tests/Cache/PsrCacheAdapterTest.php
+++ b/tests/Cache/PsrCacheAdapterTest.php
@@ -9,15 +9,16 @@ use Metadata\ClassMetadata;
 use Metadata\Tests\Fixtures\TestObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\CacheItem;
 
 /**
  * @requires PHP 5.5
  */
 class PsrCacheAdapterTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
-        if (!class_exists('Symfony\Component\Cache\CacheItem')) {
+        if (!class_exists(CacheItem::class)) {
             $this->markTestSkipped('symfony/cache is not installed.');
         }
     }

--- a/tests/ClassMetadataTest.php
+++ b/tests/ClassMetadataTest.php
@@ -5,27 +5,28 @@ declare(strict_types=1);
 namespace Metadata\Tests;
 
 use Metadata\ClassMetadata;
+use Metadata\Tests\Fixtures\TestObject;
 use PHPUnit\Framework\TestCase;
 
 class ClassMetadataTest extends TestCase
 {
     public function testConstructor()
     {
-        $metadata = new ClassMetadata('Metadata\Tests\Fixtures\TestObject');
+        $metadata = new ClassMetadata(TestObject::class);
 
         $this->assertEquals('Metadata\Tests\Fixtures\TestObject', $metadata->name);
     }
 
     public function testSerializeUnserialize()
     {
-        $metadata = new ClassMetadata('Metadata\Tests\Fixtures\TestObject');
+        $metadata = new ClassMetadata(TestObject::class);
 
         $this->assertEquals($metadata, unserialize(serialize($metadata)));
     }
 
     public function testIsFresh()
     {
-        $ref = new \ReflectionClass('Metadata\Tests\Fixtures\TestObject');
+        $ref = new \ReflectionClass(TestObject::class);
         touch($ref->getFilename());
         sleep(2);
 

--- a/tests/Driver/AbstractFileDriverTest.php
+++ b/tests/Driver/AbstractFileDriverTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Metadata\Tests\Driver;
 
 use Metadata\ClassMetadata;
+use Metadata\Driver\AbstractFileDriver;
+use Metadata\Driver\FileLocator;
+use Metadata\Driver\FileLocatorInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,10 +23,10 @@ class AbstractFileDriverTest extends TestCase
     /** @var \PHPUnit_Framework_MockObject_MockObject */
     private $driver;
 
-    public function setUp()
+    protected function setUp()
     {
-        $this->locator = $this->createMock('Metadata\Driver\FileLocator', [], [], '', false);
-        $this->driver = $this->getMockBuilder('Metadata\Driver\AbstractFileDriver')
+        $this->locator = $this->createMock(FileLocator::class, [], [], '', false);
+        $this->driver = $this->getMockBuilder(AbstractFileDriver::class)
             ->setConstructorArgs([$this->locator])
             ->getMockForAbstractClass();
 
@@ -32,7 +35,7 @@ class AbstractFileDriverTest extends TestCase
 
     public function testLoadMetadataForClass()
     {
-        $class = new \ReflectionClass('\stdClass');
+        $class = new \ReflectionClass(\stdClass::class);
         $this->locator
             ->expects($this->once())
             ->method('findFileForClass')
@@ -43,26 +46,26 @@ class AbstractFileDriverTest extends TestCase
             ->expects($this->once())
             ->method('loadMetadataFromFile')
             ->with($class, 'Some\Path')
-            ->will($this->returnValue($metadata = new ClassMetadata('\stdClass')));
+            ->will($this->returnValue($metadata = new ClassMetadata(\stdClass::class)));
 
         $this->assertSame($metadata, $this->driver->loadMetadataForClass($class));
     }
 
     public function testLoadMetadataForClassWillReturnNull()
     {
-        $class = new \ReflectionClass('\stdClass');
+        $class = new \ReflectionClass(\stdClass::class);
         $this->locator
             ->expects($this->once())
             ->method('findFileForClass')
             ->with($class, self::$extension)
             ->will($this->returnValue(null));
 
-        $this->assertSame(null, $this->driver->loadMetadataForClass($class));
+        $this->assertNull($this->driver->loadMetadataForClass($class));
     }
 
     public function testGetAllClassNames()
     {
-        $class = new \ReflectionClass('\stdClass');
+        $class = new \ReflectionClass(\stdClass::class);
         $this->locator
             ->expects($this->once())
             ->method('findAllClasses')
@@ -74,13 +77,13 @@ class AbstractFileDriverTest extends TestCase
 
     public function testGetAllClassNamesThrowsRuntimeException()
     {
-        $this->expectException('RuntimeException');
+        $this->expectException(\RuntimeException::class);
 
-        $locator = $this->createMock('Metadata\Driver\FileLocatorInterface');
-        $driver = $this->getMockBuilder('Metadata\Driver\AbstractFileDriver')
+        $locator = $this->createMock(FileLocatorInterface::class);
+        $driver = $this->getMockBuilder(AbstractFileDriver::class)
             ->setConstructorArgs([$locator])
             ->getMockForAbstractClass();
-        $class = new \ReflectionClass('\stdClass');
+        $class = new \ReflectionClass(\stdClass::class);
 
         $driver->getAllClassNames($class);
     }

--- a/tests/Driver/DriverChainTest.php
+++ b/tests/Driver/DriverChainTest.php
@@ -5,33 +5,35 @@ declare(strict_types=1);
 namespace Metadata\Tests\Driver;
 
 use Metadata\ClassMetadata;
+use Metadata\Driver\AdvancedDriverInterface;
 use Metadata\Driver\DriverChain;
+use Metadata\Driver\DriverInterface;
 use PHPUnit\Framework\TestCase;
 
 class DriverChainTest extends TestCase
 {
     public function testLoadMetadataForClass()
     {
-        $driver = $this->createMock('Metadata\\Driver\\DriverInterface');
+        $driver = $this->createMock(DriverInterface::class);
         $driver
             ->expects($this->once())
             ->method('loadMetadataForClass')
-            ->will($this->returnValue($metadata = new ClassMetadata('\stdClass')))
+            ->will($this->returnValue($metadata = new ClassMetadata(\stdClass::class)))
         ;
         $chain = new DriverChain([$driver]);
 
-        $this->assertSame($metadata, $chain->loadMetadataForClass(new \ReflectionClass('\stdClass')));
+        $this->assertSame($metadata, $chain->loadMetadataForClass(new \ReflectionClass(\stdClass::class)));
     }
 
     public function testGetAllClassNames()
     {
-        $driver1 = $this->createMock('Metadata\\Driver\\AdvancedDriverInterface');
+        $driver1 = $this->createMock(AdvancedDriverInterface::class);
         $driver1
             ->expects($this->once())
             ->method('getAllClassNames')
             ->will($this->returnValue(['Foo']));
 
-        $driver2 = $this->createMock('Metadata\\Driver\\AdvancedDriverInterface');
+        $driver2 = $this->createMock(AdvancedDriverInterface::class);
         $driver2
             ->expects($this->once())
             ->method('getAllClassNames')
@@ -45,22 +47,22 @@ class DriverChainTest extends TestCase
     public function testLoadMetadataForClassReturnsNullWhenNoMetadataIsFound()
     {
         $driver = new DriverChain([]);
-        $this->assertNull($driver->loadMetadataForClass(new \ReflectionClass('\stdClass')));
+        $this->assertNull($driver->loadMetadataForClass(new \ReflectionClass(\stdClass::class)));
 
-        $driver = $this->createMock('Metadata\\Driver\\DriverInterface');
+        $driver = $this->createMock(DriverInterface::class);
         $driver
             ->expects($this->once())
             ->method('loadMetadataForClass')
             ->will($this->returnValue(null))
         ;
-        $driverChain = new DriverChain([$driver]);
-        $this->assertNull($driver->loadMetadataForClass(new \ReflectionClass('\stdClass')));
+        new DriverChain([$driver]);
+        $this->assertNull($driver->loadMetadataForClass(new \ReflectionClass(\stdClass::class)));
     }
 
     public function testGetAllClassNamesThrowsException()
     {
-        $this->expectException('RuntimeException');
-        $driver = $this->createMock('Metadata\\Driver\\DriverInterface');
+        $this->expectException(\RuntimeException::class);
+        $driver = $this->createMock(DriverInterface::class);
         $chain = new DriverChain([$driver]);
         $chain->getAllClassNames();
     }

--- a/tests/Driver/FileLocatorTest.php
+++ b/tests/Driver/FileLocatorTest.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace Metadata\Tests\Driver;
 
 use Metadata\Driver\FileLocator;
+use Metadata\Tests\Driver\Fixture\A\A;
+use Metadata\Tests\Driver\Fixture\B\B;
+use Metadata\Tests\Driver\Fixture\C\SubDir\C;
+use Metadata\Tests\Driver\Fixture\T\T;
 use PHPUnit\Framework\TestCase;
 
 class FileLocatorTest extends TestCase
@@ -17,27 +21,23 @@ class FileLocatorTest extends TestCase
             'Metadata\Tests\Driver\Fixture\C' => __DIR__ . '/Fixture/C',
         ]);
 
-        $ref = new \ReflectionClass('Metadata\Tests\Driver\Fixture\A\A');
+        $ref = new \ReflectionClass(A::class);
         $this->assertEquals(realpath(__DIR__ . '/Fixture/A/A.xml'), realpath($locator->findFileForClass($ref, 'xml')));
 
-        $ref = new \ReflectionClass('Metadata\Tests\Driver\Fixture\B\B');
+        $ref = new \ReflectionClass(B::class);
         $this->assertNull($locator->findFileForClass($ref, 'xml'));
 
-        $ref = new \ReflectionClass('Metadata\Tests\Driver\Fixture\C\SubDir\C');
+        $ref = new \ReflectionClass(C::class);
         $this->assertEquals(realpath(__DIR__ . '/Fixture/C/SubDir.C.yml'), realpath($locator->findFileForClass($ref, 'yml')));
     }
 
     public function testTraits()
     {
-        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
-            $this->markTestSkipped('No traits available');
-        }
-
         $locator = new FileLocator([
             'Metadata\Tests\Driver\Fixture\T' => __DIR__ . '/Fixture/T',
         ]);
 
-        $ref = new \ReflectionClass('Metadata\Tests\Driver\Fixture\T\T');
+        $ref = new \ReflectionClass(T::class);
         $this->assertEquals(realpath(__DIR__ . '/Fixture/T/T.xml'), realpath($locator->findFileForClass($ref, 'xml')));
     }
 

--- a/tests/MergeableClassMetadataTest.php
+++ b/tests/MergeableClassMetadataTest.php
@@ -5,20 +5,22 @@ declare(strict_types=1);
 namespace Metadata\Tests;
 
 use Metadata\MergeableClassMetadata;
+use Metadata\Tests\Fixtures\TestObject;
+use Metadata\Tests\Fixtures\TestParent;
 use PHPUnit\Framework\TestCase;
 
 class MergeableClassMetadataTest extends TestCase
 {
     public function testMerge()
     {
-        $parentMetadata = new MergeableClassMetadata('Metadata\Tests\Fixtures\TestParent');
+        $parentMetadata = new MergeableClassMetadata(TestParent::class);
         $parentMetadata->propertyMetadata['foo'] = 'bar';
         $parentMetadata->propertyMetadata['baz'] = 'baz';
         $parentMetadata->methodMetadata['foo'] = 'bar';
         $parentMetadata->createdAt = 2;
         $parentMetadata->fileResources[] = 'foo';
 
-        $childMetadata = new MergeableClassMetadata('Metadata\Tests\Fixtures\TestObject');
+        $childMetadata = new MergeableClassMetadata(TestObject::class);
         $childMetadata->propertyMetadata['foo'] = 'baz';
         $childMetadata->methodMetadata['foo'] = 'baz';
         $childMetadata->createdAt = 1;

--- a/tests/MethodMetadataTest.php
+++ b/tests/MethodMetadataTest.php
@@ -13,18 +13,18 @@ class MethodMetadataTest extends TestCase
 {
     public function testConstructor()
     {
-        $metadata = new MethodMetadata('Metadata\Tests\Fixtures\TestObject', 'setFoo');
-        $expectedReflector = new \ReflectionMethod('Metadata\Tests\Fixtures\TestObject', 'setFoo');
+        $metadata = new MethodMetadata(TestObject::class, 'setFoo');
+        $expectedReflector = new \ReflectionMethod(TestObject::class, 'setFoo');
         $expectedReflector->setAccessible(true);
 
-        $this->assertEquals('Metadata\Tests\Fixtures\TestObject', $metadata->class);
+        $this->assertEquals(TestObject::class, $metadata->class);
         $this->assertEquals('setFoo', $metadata->name);
         $this->assertEquals($expectedReflector, $metadata->reflection);
     }
 
     public function testSerializeUnserialize()
     {
-        $metadata = new MethodMetadata('Metadata\Tests\Fixtures\TestObject', 'setFoo');
+        $metadata = new MethodMetadata(TestObject::class, 'setFoo');
 
         $this->assertEquals($metadata, unserialize(serialize($metadata)));
     }
@@ -32,7 +32,7 @@ class MethodMetadataTest extends TestCase
     public function testInvoke()
     {
         $obj = new TestObject();
-        $metadata = new MethodMetadata('Metadata\Tests\Fixtures\TestObject', 'setFoo');
+        $metadata = new MethodMetadata(TestObject::class, 'setFoo');
 
         $this->assertNull($obj->getFoo());
         $metadata->invoke($obj, ['foo']);
@@ -52,7 +52,7 @@ class MethodMetadataTest extends TestCase
     public function testLazyReflectionCreationOnUnserialize()
     {
         $metadata = new MethodMetadata(TestObject::class, 'setFoo');
-        $metadataUnserialized = unserialize(serialize($metadata));
+        unserialize(serialize($metadata));
 
         $reflectionProperty = new \ReflectionProperty(MethodMetadata::class, 'reflection');
         $reflectionProperty->setAccessible(true);

--- a/tests/PropertyMetadataTest.php
+++ b/tests/PropertyMetadataTest.php
@@ -5,20 +5,21 @@ declare(strict_types=1);
 namespace Metadata\Tests;
 
 use Metadata\PropertyMetadata;
+use Metadata\Tests\Fixtures\TestObject;
 use PHPUnit\Framework\TestCase;
 
 class PropertyMetadataTest extends TestCase
 {
     public function testConstructor()
     {
-        $metadata = new PropertyMetadata('Metadata\Tests\Fixtures\TestObject', 'foo');
-        $this->assertEquals('Metadata\Tests\Fixtures\TestObject', $metadata->class);
+        $metadata = new PropertyMetadata(TestObject::class, 'foo');
+        $this->assertEquals(Fixtures\TestObject::class, $metadata->class);
         $this->assertEquals('foo', $metadata->name);
     }
 
     public function testSerializeUnserialize()
     {
-        $metadata = new PropertyMetadata('Metadata\Tests\Fixtures\TestObject', 'foo');
+        $metadata = new PropertyMetadata(TestObject::class, 'foo');
 
         $this->assertEquals($metadata, unserialize(serialize($metadata)));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

# Changed log

- Add `php-7.2` and `php-7.3` version tests on Travis CI build.
- Using the `::class` magic class string call to replace the class name string.
- Removing unused variables.
- Using the `assertCount` to assert the expected count value is same as result count value.
- According to the [PHPUnit fixture reference](https://phpunit.de/manual/7.0/en/fixtures.html), the `setUp` method is `protected`, not `public`.

When using the composer `--prefer-lowest` and `--prefer-stable` flags on `php-7.2` version, this will cause the following coding style issue:

```
 php vendor/bin/phpcs                           19.5s
............................................E 45 / 45 (100%)



FILE: src/MetadataFactory.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 36 | ERROR | Class MetadataFactory contains write-only property
    |       | $hierarchyMetadataClass.
    |       | (SlevomatCodingStandard.Classes.UnusedPrivateElements.WriteOnlyProperty)
--------------------------------------------------------------------------------

Time: 804ms; Memory: 8Mb
```

It seems that the private `$hierarchyMetadataClass` variable is unused.

To pass this coding style check, removing this variable.