### PR TITLE
Add recursion to FileLocator

### DIFF
--- a/src/Driver/FileLocator.php
+++ b/src/Driver/FileLocator.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Metadata\Driver;
 
+use function file_exists;
+use function str_replace;
+use function strpos;
+use function substr;
+
 class FileLocator implements AdvancedFileLocatorInterface
 {
     /**
@@ -27,9 +32,19 @@ class FileLocator implements AdvancedFileLocatorInterface
             }
 
             $len = '' === $prefix ? 0 : strlen($prefix) + 1;
-            $path = $dir . '/' . str_replace('\\', '.', substr($class->name, $len)) . '.' . $extension;
-            if (file_exists($path)) {
-                return $path;
+            $fqcn = str_replace('\\', '.', substr($class->name, $len));
+
+            while (true) {
+                $path = $dir . '/' . $fqcn . '.' . $extension;
+                if (file_exists($path)) {
+                    return $path;
+                }
+
+                if (false === strpos($fqcn, '.')) {
+                    break;
+                }
+
+                $fqcn = substr($fqcn, 0, strrpos($fqcn, '.'));
             }
         }
 

--- a/tests/Driver/FileLocatorTest.php
+++ b/tests/Driver/FileLocatorTest.php
@@ -7,9 +7,11 @@ namespace Metadata\Tests\Driver;
 use Metadata\Driver\FileLocator;
 use Metadata\Tests\Driver\Fixture\A\A;
 use Metadata\Tests\Driver\Fixture\B\B;
+use Metadata\Tests\Driver\Fixture\B\SubDir\BB;
 use Metadata\Tests\Driver\Fixture\C\SubDir\C;
 use Metadata\Tests\Driver\Fixture\T\T;
 use PHPUnit\Framework\TestCase;
+use function realpath;
 
 class FileLocatorTest extends TestCase
 {
@@ -26,6 +28,9 @@ class FileLocatorTest extends TestCase
 
         $ref = new \ReflectionClass(B::class);
         $this->assertNull($locator->findFileForClass($ref, 'xml'));
+
+        $ref = new \ReflectionClass(BB::class);
+        $this->assertEquals(realpath(__DIR__ . '/Fixture/B/SubDir.yml'), realpath($locator->findFileForClass($ref, 'yml')));
 
         $ref = new \ReflectionClass(C::class);
         $this->assertEquals(realpath(__DIR__ . '/Fixture/C/SubDir.C.yml'), realpath($locator->findFileForClass($ref, 'yml')));
@@ -64,9 +69,10 @@ class FileLocatorTest extends TestCase
         $this->assertCount(1, $xmlFiles = $locator->findAllClasses('xml'));
         $this->assertSame('Metadata\Tests\Driver\Fixture\A\A', $xmlFiles[0]);
 
-        $this->assertCount(3, $ymlFiles = $locator->findAllClasses('yml'));
+        $this->assertCount(4, $ymlFiles = $locator->findAllClasses('yml'));
         $this->assertSame('Metadata\Tests\Driver\Fixture\B\B', $ymlFiles[0]);
-        $this->assertSame('Metadata\Tests\Driver\Fixture\C\SubDir\C', $ymlFiles[1]);
-        $this->assertSame('Metadata\Tests\Driver\Fixture\D\D', $ymlFiles[2]);
+        $this->assertSame('Metadata\Tests\Driver\Fixture\B\SubDir', $ymlFiles[1]);
+        $this->assertSame('Metadata\Tests\Driver\Fixture\C\SubDir\C', $ymlFiles[2]);
+        $this->assertSame('Metadata\Tests\Driver\Fixture\D\D', $ymlFiles[3]);
     }
 }

--- a/tests/Driver/Fixture/B/SubDir/BB.php
+++ b/tests/Driver/Fixture/B/SubDir/BB.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Metadata\Tests\Driver\Fixture\B\SubDir;
+
+class BB
+{
+}


### PR DESCRIPTION
The FileLocator uses an array of directories to search for metadata for the given class. It will then loop over this array and try to find exact matches by converting backslashes in the FQCN to dots and appending the extension.

Because of this, it will always try to do an exact match. If it cannot find that file, it will continue to the next directory.

If you need to add metadata to a lot of classes, this quickly becomes very messy. You need to create a single file for every class you want to support.

With this change, it should be easier. You can now add multiple definitions in 1 metadata file. The FileLocator will now loop every FQCN until it finds the top level namespace.

Signed-off-by: Ruud Kamphuis <ruudk@users.noreply.github.com>

| Q             | A
| ------------- | ---
| Bug fix?      |no
| New feature?  | yes
| Doc updated   |no
| BC breaks?    | don't know
| Deprecations? |no 
| Tests pass?   | yes
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

