### PR TITLE
Make exception more descriptive when trying to cache anonymous class using FileCache (#79)

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -28,8 +28,12 @@ class FileCache implements CacheInterface
     public function load(string $class): ?ClassMetadata
     {
         $path = $this->dir . '/' . strtr($class, '\\', '-') . '.cache.php';
-        if (!file_exists($path)) {
-            return null;
+        try {
+            if (!file_exists($path)) {
+                return null;
+            }
+        } catch (\TypeError $e) {
+            throw new \InvalidArgumentException(sprintf('Invalid path provided %s.', $path));
         }
 
         try {
@@ -84,7 +88,13 @@ class FileCache implements CacheInterface
      */
     private function renameFile(string $source, string $target): void
     {
-        if (false === @rename($source, $target)) {
+        try {
+            $renamed = @rename($source, $target);
+        } catch (\TypeError $e) {
+            throw new \InvalidArgumentException(sprintf('Could not write new cache file to %s.', $target));
+        }
+
+        if (false === $renamed) {
             if (defined('PHP_WINDOWS_VERSION_BUILD')) {
                 if (false === copy($source, $target)) {
                     throw new \RuntimeException(sprintf('(WIN) Could not write new cache file to %s.', $target));
@@ -104,8 +114,12 @@ class FileCache implements CacheInterface
     public function evict(string $class): void
     {
         $path = $this->dir . '/' . strtr($class, '\\', '-') . '.cache.php';
-        if (file_exists($path)) {
-            unlink($path);
+        try {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        } catch (\TypeError $e) {
+            throw new \InvalidArgumentException(sprintf('Invalid path provided %s.', $path));
         }
     }
 }

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -53,4 +53,34 @@ class FileCacheTest extends TestCase
 
         $this->assertNull($cache->load(TestObject::class));
     }
+
+    public function testLoadAnonymousClassMetadataFromCacheThrowsException()
+    {
+        $cache = new FileCache($this->dir);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid path provided');
+
+        $cache->load(get_class(new class {}));
+    }
+
+    public function testPutAnonymousClassMetadataInCacheThrowsException()
+    {
+        $cache = new FileCache($this->dir);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not write new cache file to');
+
+        $cache->put(new ClassMetadata(get_class(new class {})));
+    }
+
+    public function testEvictAnonymousClassMetadataFromCacheThrowsException()
+    {
+        $cache = new FileCache($this->dir);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid path provided');
+
+        $cache->evict(get_class(new class {}));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #79
| License       | MIT

Fixing https://github.com/schmittjoh/metadata/issues/79. Tested locally with:
1. Cache `none` - no applicable then as the issue occurs only when trying to cache anonymous class meta data.
2. Cache `DoctrineCacheAdapter` using `ApcuCache` and `PhpFileCache` - this adapter seems to work so no changes needed.
3. Cache `PsrCacheAdapter` using `cache.adapter.apcu` and `cache.adapter.filesystem` - this one already throws a descriptive enough exception (https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Cache/CacheItem.php#L165):
```
{
  "code": 500,
  "message": "Cache key \"testclass@anonymous\u0000/app/src/Controller/DefaultController.php0x7fabd900b6ec\" contains reserved characters {}()/\\@:"
}
```
4. Cache `FileCache` (default value) - throws now `InvalidArgumentException` with a message:

Old response:
```
{
  "code": 500,
  "message": "file_exists() expects parameter 1 to be a valid path, string given"
}
```
New response:
```
{
  "code": 500,
  "message": "Invalid path provided /app/var/cache/dev/jms_serializer/class@anonymous\u0000/app/src/Controller/DefaultController.php0x7fabd900b6ec.cache.php."
}
```
Old response:
```
{
  "code": 500,
  "message": "rename() expects parameter 2 to be a valid path, string given"
}
```
New response:
```
{
  "code": 500,
  "message": "Could not write new cache file to /app/var/cache/dev/jms_serializer/class@anonymous\u0000/app/src/Controller/DefaultController.php0x7fabd900b6ec.cache.php."
}
```

Alternative solutions I considered:
- Adding ` (check if not caching anonymous class)` at the end of each exception message
- Validating class with `if ((new ReflectionClass($class))->isAnonymous()) {` (slower) or `if (!preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $class)) {` (faster, regex from https://www.php.net/manual/en/language.oop5.basic.php#language.oop5.basic.class), but it seems to be cleaner and faster to catch `TypeError`