### PR TITLE
Revert "Add recursion to FileLocator"

### DIFF
--- a/src/Driver/FileLocator.php
+++ b/src/Driver/FileLocator.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 
 namespace Metadata\Driver;
 
-use function file_exists;
-use function str_replace;
-use function strpos;
-use function substr;
-
 class FileLocator implements AdvancedFileLocatorInterface
 {
     /**
@@ -32,19 +27,9 @@ class FileLocator implements AdvancedFileLocatorInterface
             }
 
             $len = '' === $prefix ? 0 : strlen($prefix) + 1;
-            $fqcn = str_replace('\\', '.', substr($class->name, $len));
-
-            while (true) {
-                $path = $dir . '/' . $fqcn . '.' . $extension;
-                if (file_exists($path)) {
-                    return $path;
-                }
-
-                if (false === strpos($fqcn, '.')) {
-                    break;
-                }
-
-                $fqcn = substr($fqcn, 0, strrpos($fqcn, '.'));
+            $path = $dir . '/' . str_replace('\\', '.', substr($class->name, $len)) . '.' . $extension;
+            if (file_exists($path)) {
+                return $path;
             }
         }
 

--- a/tests/Driver/FileLocatorTest.php
+++ b/tests/Driver/FileLocatorTest.php
@@ -7,11 +7,9 @@ namespace Metadata\Tests\Driver;
 use Metadata\Driver\FileLocator;
 use Metadata\Tests\Driver\Fixture\A\A;
 use Metadata\Tests\Driver\Fixture\B\B;
-use Metadata\Tests\Driver\Fixture\B\SubDir\BB;
 use Metadata\Tests\Driver\Fixture\C\SubDir\C;
 use Metadata\Tests\Driver\Fixture\T\T;
 use PHPUnit\Framework\TestCase;
-use function realpath;
 
 class FileLocatorTest extends TestCase
 {
@@ -28,9 +26,6 @@ class FileLocatorTest extends TestCase
 
         $ref = new \ReflectionClass(B::class);
         $this->assertNull($locator->findFileForClass($ref, 'xml'));
-
-        $ref = new \ReflectionClass(BB::class);
-        $this->assertEquals(realpath(__DIR__ . '/Fixture/B/SubDir.yml'), realpath($locator->findFileForClass($ref, 'yml')));
 
         $ref = new \ReflectionClass(C::class);
         $this->assertEquals(realpath(__DIR__ . '/Fixture/C/SubDir.C.yml'), realpath($locator->findFileForClass($ref, 'yml')));
@@ -69,10 +64,9 @@ class FileLocatorTest extends TestCase
         $this->assertCount(1, $xmlFiles = $locator->findAllClasses('xml'));
         $this->assertSame('Metadata\Tests\Driver\Fixture\A\A', $xmlFiles[0]);
 
-        $this->assertCount(4, $ymlFiles = $locator->findAllClasses('yml'));
+        $this->assertCount(3, $ymlFiles = $locator->findAllClasses('yml'));
         $this->assertSame('Metadata\Tests\Driver\Fixture\B\B', $ymlFiles[0]);
-        $this->assertSame('Metadata\Tests\Driver\Fixture\B\SubDir', $ymlFiles[1]);
-        $this->assertSame('Metadata\Tests\Driver\Fixture\C\SubDir\C', $ymlFiles[2]);
-        $this->assertSame('Metadata\Tests\Driver\Fixture\D\D', $ymlFiles[3]);
+        $this->assertSame('Metadata\Tests\Driver\Fixture\C\SubDir\C', $ymlFiles[1]);
+        $this->assertSame('Metadata\Tests\Driver\Fixture\D\D', $ymlFiles[2]);
     }
 }

--- a/tests/Driver/Fixture/B/SubDir/BB.php
+++ b/tests/Driver/Fixture/B/SubDir/BB.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Metadata\Tests\Driver\Fixture\B\SubDir;
-
-class BB
-{
-}


### PR DESCRIPTION
This reverts commit 092b94df35862670a1c0411b66a872070ed2b53d, reversing
changes made to 8692edce16b26afd1cc68e0a23c9731bd2d3e15b.
Revert https://github.com/schmittjoh/metadata/pull/85

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT

ping @ruudk


I have tested this and does not work i the following case:

- class `App\User` (data defined in `metadata/User.yml`)
- class `App\User\Permission` (no metadata defined)

The current implementation throws an exception when loading metadata for   `App\User\Permission` because tries to load them from `metadata/User.yml` (that does not have them defined)

This is a major BC creak that impacts on https://github.com/willdurand/Hateoas too





