### PR TITLE
Add cache support for anonymous classes (#79)

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -113,11 +113,9 @@ class FileCache implements CacheInterface
      * If anonymous class is to be cached, it contains invalid path characters that need to be removed/replaced
      * Example of anonymous class name: class@anonymous\x00/app/src/Controller/DefaultController.php0x7f82a7e026ec
      *
-     * @param string $key
-     * @return string
      */
     private function sanitizeCacheKey(string $key): string
     {
-        return strtr($key, ['\\' => '-', "\0" => '', '@' => '-', '/' => '-', '.' => '-']);
+        return str_replace(['\\', "\0", '@', '/', '$', '{', '}', ':'], '-', $key);
     }
 }

--- a/src/Cache/PsrCacheAdapter.php
+++ b/src/Cache/PsrCacheAdapter.php
@@ -66,11 +66,9 @@ class PsrCacheAdapter implements CacheInterface
      * If anonymous class is to be cached, it contains invalid path characters that need to be removed/replaced
      * Example of anonymous class name: class@anonymous\x00/app/src/Controller/DefaultController.php0x7f82a7e026ec
      *
-     * @param string $key
-     * @return string
      */
     private function sanitizeCacheKey(string $key): string
     {
-        return strtr($key, ['\\' => '.', "\0" => '', '@' => '.', '/' => '.']);
+        return str_replace(['\\', "\0", '@', '/', '$', '{', '}', ':'], '-', $key);
     }
 }

--- a/src/Cache/PsrCacheAdapter.php
+++ b/src/Cache/PsrCacheAdapter.php
@@ -35,7 +35,7 @@ class PsrCacheAdapter implements CacheInterface
      */
     public function load(string $class): ?ClassMetadata
     {
-        $this->lastItem = $this->pool->getItem(strtr($this->prefix . $class, '\\', '.'));
+        $this->lastItem = $this->pool->getItem($this->sanitizeCacheKey($this->prefix . $class));
 
         return $this->lastItem->get();
     }
@@ -45,7 +45,7 @@ class PsrCacheAdapter implements CacheInterface
      */
     public function put(ClassMetadata $metadata): void
     {
-        $key = strtr($this->prefix . $metadata->name, '\\', '.');
+        $key = $this->sanitizeCacheKey($this->prefix . $metadata->name);
 
         if (null === $this->lastItem || $this->lastItem->getKey() !== $key) {
             $this->lastItem = $this->pool->getItem($key);
@@ -59,6 +59,18 @@ class PsrCacheAdapter implements CacheInterface
      */
     public function evict(string $class): void
     {
-        $this->pool->deleteItem(strtr($this->prefix . $class, '\\', '.'));
+        $this->pool->deleteItem($this->sanitizeCacheKey($this->prefix . $class));
+    }
+
+    /**
+     * If anonymous class is to be cached, it contains invalid path characters that need to be removed/replaced
+     * Example of anonymous class name: class@anonymous\x00/app/src/Controller/DefaultController.php0x7f82a7e026ec
+     *
+     * @param string $key
+     * @return string
+     */
+    private function sanitizeCacheKey(string $key): string
+    {
+        return strtr($key, ['\\' => '.', "\0" => '', '@' => '.', '/' => '.']);
     }
 }

--- a/tests/Cache/DoctrineCacheAdapterTest.php
+++ b/tests/Cache/DoctrineCacheAdapterTest.php
@@ -43,7 +43,10 @@ class DoctrineCacheAdapterTest extends TestCase
     {
         return [
             'TestObject' => [TestObject::class],
-            'anonymous class' => [get_class(new class {})]
+            'anonymous class' => [
+                get_class(new class {
+                }),
+            ],
         ];
     }
 }

--- a/tests/Cache/DoctrineCacheAdapterTest.php
+++ b/tests/Cache/DoctrineCacheAdapterTest.php
@@ -22,16 +22,28 @@ class DoctrineCacheAdapterTest extends TestCase
         }
     }
 
-    public function testLoadEvictPutClassMetadataFromInCache()
+    /**
+     * @dataProvider classNameProvider
+     * @param string $className
+     */
+    public function testLoadEvictPutClassMetadataFromInCache(string $className)
     {
         $cache = new DoctrineCacheAdapter('metadata-test', new ArrayCache());
 
-        $this->assertNull($cache->load(TestObject::class));
-        $cache->put($metadata = new ClassMetadata(TestObject::class));
+        $this->assertNull($cache->load($className));
+        $cache->put($metadata = new ClassMetadata($className));
 
-        $this->assertEquals($metadata, $cache->load(TestObject::class));
+        $this->assertEquals($metadata, $cache->load($className));
 
-        $cache->evict(TestObject::class);
-        $this->assertNull($cache->load(TestObject::class));
+        $cache->evict($className);
+        $this->assertNull($cache->load($className));
+    }
+
+    public function classNameProvider()
+    {
+        return [
+            'TestObject' => [TestObject::class],
+            'anonymous class' => [get_class(new class {})]
+        ];
     }
 }

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -44,7 +44,10 @@ class FileCacheTest extends TestCase
     {
         return [
             'TestObject' => [TestObject::class],
-            'anonymous class' => [get_class(new class {})]
+            'anonymous class' => [
+                get_class(new class {
+                }),
+            ],
         ];
     }
 

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -23,17 +23,29 @@ class FileCacheTest extends TestCase
         }
     }
 
-    public function testLoadEvictPutClassMetadataFromInCache()
+    /**
+     * @dataProvider classNameProvider
+     * @param string $className
+     */
+    public function testLoadEvictPutClassMetadataFromInCache(string $className)
     {
         $cache = new FileCache($this->dir);
 
-        $this->assertNull($cache->load(TestObject::class));
-        $cache->put($metadata = new ClassMetadata(TestObject::class));
+        $this->assertNull($cache->load($className));
+        $cache->put($metadata = new ClassMetadata($className));
 
-        $this->assertEquals($metadata, $cache->load(TestObject::class));
+        $this->assertEquals($metadata, $cache->load($className));
 
-        $cache->evict(TestObject::class);
-        $this->assertNull($cache->load(TestObject::class));
+        $cache->evict($className);
+        $this->assertNull($cache->load($className));
+    }
+
+    public function classNameProvider()
+    {
+        return [
+            'TestObject' => [TestObject::class],
+            'anonymous class' => [get_class(new class {})]
+        ];
     }
 
     public function provideCorruptedCache()

--- a/tests/Cache/PsrCacheAdapterTest.php
+++ b/tests/Cache/PsrCacheAdapterTest.php
@@ -23,16 +23,28 @@ class PsrCacheAdapterTest extends TestCase
         }
     }
 
-    public function testLoadEvictPutClassMetadataFromInCache()
+    /**
+     * @dataProvider classNameProvider
+     * @param string $className
+     */
+    public function testLoadEvictPutClassMetadataFromInCache(string $className)
     {
         $cache = new PsrCacheAdapter('metadata-test', new ArrayAdapter());
 
-        $this->assertNull($cache->load(TestObject::class));
-        $cache->put($metadata = new ClassMetadata(TestObject::class));
+        $this->assertNull($cache->load($className));
+        $cache->put($metadata = new ClassMetadata($className));
 
-        $this->assertEquals($metadata, $cache->load(TestObject::class));
+        $this->assertEquals($metadata, $cache->load($className));
 
-        $cache->evict(TestObject::class);
-        $this->assertNull($cache->load(TestObject::class));
+        $cache->evict($className);
+        $this->assertNull($cache->load($className));
+    }
+
+    public function classNameProvider()
+    {
+        return [
+            'TestObject' => [TestObject::class],
+            'anonymous class' => [get_class(new class {})]
+        ];
     }
 }

--- a/tests/Cache/PsrCacheAdapterTest.php
+++ b/tests/Cache/PsrCacheAdapterTest.php
@@ -44,7 +44,10 @@ class PsrCacheAdapterTest extends TestCase
     {
         return [
             'TestObject' => [TestObject::class],
-            'anonymous class' => [get_class(new class {})]
+            'anonymous class' => [
+                get_class(new class {
+                }),
+            ],
         ];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #79
| License       | MIT

Fixing https://github.com/schmittjoh/metadata/issues/79. Tested locally with:
1. Cache `none` - no applicable then as the issue occurs only when trying to cache anonymous class meta data.
2. Cache `FileCache` (default value) - working with anonymous classes after the my changes.
3. Cache `DoctrineCacheAdapter` using `ApcuCache` and `PhpFileCache` - this adapter seem to work so no changes needed.
4. Cache `PsrCacheAdapter` using `cache.adapter.apcu` and `cache.adapter.filesystem` - working with anonymous classes after the my changes.

Text copied from the orginal https://github.com/schmittjoh/metadata/pull/87

Closes #87
Closes #79