### PR TITLE
Test against PHP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,13 @@ matrix:
         - php: 7.2
           env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
         - php: 7.3
+        - php: 7.4
+        - php: nightly
     fast_finish: true
 
 before_script:
     - if [[ $TRAVIS_PHP_VERSION  = '7.2' ]]; then PHPUNIT_FLAGS="--coverage-clover clover"; else PHPUNIT_FLAGS=""; fi
-    - if [[ $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
+    - if [[ $TRAVIS_PHP_VERSION != '7.2' ]] && [[ $TRAVIS_PHP_VERSION != 'nightly' ]]; then phpenv config-rm xdebug.ini; fi
     - composer self-update
     - composer update $COMPOSER_FLAGS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 
 before_script:
     - if [[ $TRAVIS_PHP_VERSION  = '7.2' ]]; then PHPUNIT_FLAGS="--coverage-clover clover"; else PHPUNIT_FLAGS=""; fi
-    - if [[ $TRAVIS_PHP_VERSION != '7.2' ]] && [[ $TRAVIS_PHP_VERSION != 'nightly' ]]; then phpenv config-rm xdebug.ini; fi
+    - if [[ $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
     - composer self-update
     - composer update $COMPOSER_FLAGS
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev" : {
         "doctrine/cache" : "^1.0",
-        "doctrine/coding-standard": "^4.0",
+        "doctrine/coding-standard": "^8.0",
         "phpunit/phpunit": "^8.0|^9.0",
         "psr/container": "^1.0",
         "symfony/cache" : "^3.1|^4.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev" : {
         "doctrine/cache" : "^1.0",
         "doctrine/coding-standard": "^8.0",
-        "phpunit/phpunit": "^8.0|^9.0",
+        "phpunit/phpunit": "^8.5|^9.0",
         "psr/container": "^1.0",
         "symfony/cache" : "^3.1|^4.0|^5.0",
         "symfony/dependency-injection" : "^3.1|^4.0|^5.0"

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,15 @@
         }
     ],
     "require": {
-        "php": "^7.2"
+        "php": "^7.2|^8.0"
     },
     "require-dev" : {
-        "phpunit/phpunit": "^7.0",
         "doctrine/cache" : "^1.0",
+        "doctrine/coding-standard": "^4.0",
+        "phpunit/phpunit": "^8.0|^9.0",
+        "psr/container": "^1.0",
         "symfony/cache" : "^3.1|^4.0|^5.0",
-        "symfony/dependency-injection" : "^3.1|^4.0|^5.0",
-        "doctrine/coding-standard": "^4.0"
+        "symfony/dependency-injection" : "^3.1|^4.0|^5.0"
     },
     "autoload": {
         "psr-4": { "Metadata\\": "src/" }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -90,10 +90,19 @@
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
 
-    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration">
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements">
+        <exclude-pattern>tests/*</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaMagicConstant">
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -93,15 +93,23 @@
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint">
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
+
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
+
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint">
+        <exclude-pattern>src/*</exclude-pattern>
+    </rule>
+
     <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements">
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>
+
     <rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference.ClassNameReferencedViaMagicConstant">
         <exclude-pattern>tests/*</exclude-pattern>
     </rule>

--- a/src/AdvancedMetadataFactoryInterface.php
+++ b/src/AdvancedMetadataFactoryInterface.php
@@ -15,8 +15,9 @@ interface AdvancedMetadataFactoryInterface extends MetadataFactoryInterface
     /**
      * Gets all the possible classes.
      *
-     * @throws \RuntimeException When driver does not an advanced driver.
      * @return string[]
+     *
+     * @throws \RuntimeException When driver does not an advanced driver.
      */
     public function getAllClassNames(): array;
 }

--- a/src/Cache/DoctrineCacheAdapter.php
+++ b/src/Cache/DoctrineCacheAdapter.php
@@ -13,12 +13,10 @@ use Metadata\ClassMetadata;
 class DoctrineCacheAdapter implements CacheInterface
 {
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     private $prefix;
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var Cache
      */
     private $cache;

--- a/src/Cache/DoctrineCacheAdapter.php
+++ b/src/Cache/DoctrineCacheAdapter.php
@@ -13,10 +13,12 @@ use Metadata\ClassMetadata;
 class DoctrineCacheAdapter implements CacheInterface
 {
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     private $prefix;
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var Cache
      */
     private $cache;
@@ -27,26 +29,18 @@ class DoctrineCacheAdapter implements CacheInterface
         $this->cache = $cache;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function load(string $class): ?ClassMetadata
     {
         $cache = $this->cache->fetch($this->prefix . $class);
+
         return false === $cache ? null : $cache;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function put(ClassMetadata $metadata): void
     {
         $this->cache->save($this->prefix . $metadata->name, $metadata);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function evict(string $class): void
     {
         $this->cache->delete($this->prefix . $class);

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -9,6 +9,7 @@ use Metadata\ClassMetadata;
 class FileCache implements CacheInterface
 {
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     private $dir;
@@ -22,9 +23,6 @@ class FileCache implements CacheInterface
         $this->dir = rtrim($dir, '\\/');
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function load(string $class): ?ClassMetadata
     {
         $path = $this->dir . '/' . $this->sanitizeCacheKey($class) . '.cache.php';
@@ -37,6 +35,7 @@ class FileCache implements CacheInterface
             if ($metadata instanceof ClassMetadata) {
                 return $metadata;
             }
+
             // if the file does not return anything, the return value is integer `1`.
         } catch (\ParseError $e) {
             // ignore corrupted cache
@@ -45,9 +44,6 @@ class FileCache implements CacheInterface
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function put(ClassMetadata $metadata): void
     {
         if (!is_writable($this->dir)) {
@@ -62,6 +58,7 @@ class FileCache implements CacheInterface
 
             return;
         }
+
         $data = '<?php return unserialize(' . var_export(serialize($metadata), true) . ');';
         $bytesWritten = file_put_contents($tmpFile, $data);
         // use strlen and not mb_strlen. if there is utf8 in the code, it also writes more bytes.
@@ -80,7 +77,6 @@ class FileCache implements CacheInterface
 
     /**
      * Renames a file with fallback for windows
-     *
      */
     private function renameFile(string $source, string $target): void
     {
@@ -89,6 +85,7 @@ class FileCache implements CacheInterface
                 if (false === copy($source, $target)) {
                     throw new \RuntimeException(sprintf('(WIN) Could not write new cache file to %s.', $target));
                 }
+
                 if (false === unlink($source)) {
                     throw new \RuntimeException(sprintf('(WIN) Could not delete temp cache file to %s.', $source));
                 }
@@ -98,9 +95,6 @@ class FileCache implements CacheInterface
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function evict(string $class): void
     {
         $path = $this->dir . '/' . $this->sanitizeCacheKey($class) . '.cache.php';
@@ -112,7 +106,6 @@ class FileCache implements CacheInterface
     /**
      * If anonymous class is to be cached, it contains invalid path characters that need to be removed/replaced
      * Example of anonymous class name: class@anonymous\x00/app/src/Controller/DefaultController.php0x7f82a7e026ec
-     *
      */
     private function sanitizeCacheKey(string $key): string
     {

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -9,7 +9,6 @@ use Metadata\ClassMetadata;
 class FileCache implements CacheInterface
 {
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     private $dir;
@@ -64,7 +63,8 @@ class FileCache implements CacheInterface
         // use strlen and not mb_strlen. if there is utf8 in the code, it also writes more bytes.
         if ($bytesWritten !== strlen($data)) {
             @unlink($tmpFile);
-            $this->evict($metadata->name); // also evict the cache to not use an outdated version.
+            // also evict the cache to not use an outdated version.
+            $this->evict($metadata->name);
 
             return;
         }

--- a/src/Cache/PsrCacheAdapter.php
+++ b/src/Cache/PsrCacheAdapter.php
@@ -10,16 +10,19 @@ use Psr\Cache\CacheItemPoolInterface;
 class PsrCacheAdapter implements CacheInterface
 {
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     private $prefix;
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var CacheItemPoolInterface
      */
     private $pool;
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var CacheItemPoolInterface
      */
     private $lastItem;
@@ -30,9 +33,6 @@ class PsrCacheAdapter implements CacheInterface
         $this->pool = $pool;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function load(string $class): ?ClassMetadata
     {
         $this->lastItem = $this->pool->getItem($this->sanitizeCacheKey($this->prefix . $class));
@@ -40,9 +40,6 @@ class PsrCacheAdapter implements CacheInterface
         return $this->lastItem->get();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function put(ClassMetadata $metadata): void
     {
         $key = $this->sanitizeCacheKey($this->prefix . $metadata->name);
@@ -54,9 +51,6 @@ class PsrCacheAdapter implements CacheInterface
         $this->pool->save($this->lastItem->set($metadata));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function evict(string $class): void
     {
         $this->pool->deleteItem($this->sanitizeCacheKey($this->prefix . $class));
@@ -65,7 +59,6 @@ class PsrCacheAdapter implements CacheInterface
     /**
      * If anonymous class is to be cached, it contains invalid path characters that need to be removed/replaced
      * Example of anonymous class name: class@anonymous\x00/app/src/Controller/DefaultController.php0x7f82a7e026ec
-     *
      */
     private function sanitizeCacheKey(string $key): string
     {

--- a/src/Cache/PsrCacheAdapter.php
+++ b/src/Cache/PsrCacheAdapter.php
@@ -10,19 +10,16 @@ use Psr\Cache\CacheItemPoolInterface;
 class PsrCacheAdapter implements CacheInterface
 {
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     private $prefix;
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var CacheItemPoolInterface
      */
     private $pool;
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var CacheItemPoolInterface
      */
     private $lastItem;

--- a/src/ClassHierarchyMetadata.php
+++ b/src/ClassHierarchyMetadata.php
@@ -12,7 +12,6 @@ namespace Metadata;
 class ClassHierarchyMetadata
 {
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var ClassMetadata[]
      */
     public $classMetadata = [];

--- a/src/ClassHierarchyMetadata.php
+++ b/src/ClassHierarchyMetadata.php
@@ -12,6 +12,7 @@ namespace Metadata;
 class ClassHierarchyMetadata
 {
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var ClassMetadata[]
      */
     public $classMetadata = [];

--- a/src/ClassMetadata.php
+++ b/src/ClassMetadata.php
@@ -15,26 +15,31 @@ namespace Metadata;
 class ClassMetadata implements \Serializable
 {
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     public $name;
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var MethodMetadata[]
      */
     public $methodMetadata = [];
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var PropertyMetadata[]
      */
     public $propertyMetadata = [];
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string[]
      */
     public $fileResources = [];
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var int
      */
     public $createdAt;
@@ -75,11 +80,10 @@ class ClassMetadata implements \Serializable
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     *
      * @return string
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
      */
     public function serialize()
     {
@@ -93,21 +97,22 @@ class ClassMetadata implements \Serializable
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     *
      * @param string $str
+     *
      * @return void
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
      */
     public function unserialize($str)
     {
-        list(
+        [
             $this->name,
             $this->methodMetadata,
             $this->propertyMetadata,
             $this->fileResources,
-            $this->createdAt
-            ) = unserialize($str);
+            $this->createdAt,
+        ] = unserialize($str);
     }
 }

--- a/src/ClassMetadata.php
+++ b/src/ClassMetadata.php
@@ -15,31 +15,26 @@ namespace Metadata;
 class ClassMetadata implements \Serializable
 {
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     public $name;
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var MethodMetadata[]
      */
     public $methodMetadata = [];
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var PropertyMetadata[]
      */
     public $propertyMetadata = [];
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string[]
      */
     public $fileResources = [];
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var int
      */
     public $createdAt;

--- a/src/Driver/AdvancedFileLocatorInterface.php
+++ b/src/Driver/AdvancedFileLocatorInterface.php
@@ -13,6 +13,7 @@ interface AdvancedFileLocatorInterface extends FileLocatorInterface
 {
     /**
      * Finds all possible metadata files.*
+     *
      * @return string[]
      */
     public function findAllClasses(string $extension): array;

--- a/src/Driver/DriverChain.php
+++ b/src/Driver/DriverChain.php
@@ -9,6 +9,7 @@ use Metadata\ClassMetadata;
 final class DriverChain implements AdvancedDriverInterface
 {
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var DriverInterface[]
      */
     private $drivers;
@@ -53,6 +54,7 @@ final class DriverChain implements AdvancedDriverInterface
                     )
                 );
             }
+
             $driverClasses = $driver->getAllClassNames();
             if (!empty($driverClasses)) {
                 $classes = array_merge($classes, $driverClasses);

--- a/src/Driver/DriverChain.php
+++ b/src/Driver/DriverChain.php
@@ -9,7 +9,6 @@ use Metadata\ClassMetadata;
 final class DriverChain implements AdvancedDriverInterface
 {
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var DriverInterface[]
      */
     private $drivers;

--- a/src/Driver/FileLocator.php
+++ b/src/Driver/FileLocator.php
@@ -7,7 +7,6 @@ namespace Metadata\Driver;
 class FileLocator implements AdvancedFileLocatorInterface
 {
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string[]
      */
     private $dirs;

--- a/src/Driver/FileLocator.php
+++ b/src/Driver/FileLocator.php
@@ -7,6 +7,7 @@ namespace Metadata\Driver;
 class FileLocator implements AdvancedFileLocatorInterface
 {
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string[]
      */
     private $dirs;

--- a/src/Driver/LazyLoadingDriver.php
+++ b/src/Driver/LazyLoadingDriver.php
@@ -16,7 +16,6 @@ class LazyLoadingDriver implements DriverInterface
     private $container;
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     private $realDriverId;

--- a/src/Driver/LazyLoadingDriver.php
+++ b/src/Driver/LazyLoadingDriver.php
@@ -16,6 +16,7 @@ class LazyLoadingDriver implements DriverInterface
     private $container;
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     private $realDriverId;
@@ -28,13 +29,11 @@ class LazyLoadingDriver implements DriverInterface
         if (!$container instanceof PsrContainerInterface && !$container instanceof ContainerInterface) {
             throw new \InvalidArgumentException(sprintf('The container must be an instance of %s or %s (%s given).', PsrContainerInterface::class, ContainerInterface::class, \is_object($container) ? \get_class($container) : \gettype($container)));
         }
+
         $this->container = $container;
         $this->realDriverId = $realDriverId;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function loadMetadataForClass(\ReflectionClass $class): ?ClassMetadata
     {
         return $this->container->get($this->realDriverId)->loadMetadataForClass($class);

--- a/src/MetadataFactory.php
+++ b/src/MetadataFactory.php
@@ -11,43 +11,36 @@ use Metadata\Driver\DriverInterface;
 class MetadataFactory implements AdvancedMetadataFactoryInterface
 {
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var DriverInterface
      */
     private $driver;
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var CacheInterface
      */
     private $cache;
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var ClassMetadata[]
      */
     private $loadedMetadata = [];
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var ClassMetadata[]
      */
     private $loadedClassMetadata = [];
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string|null
      */
     private $hierarchyMetadataClass;
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var bool
      */
     private $includeInterfaces = false;
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var bool
      */
     private $debug = false;

--- a/src/MetadataFactory.php
+++ b/src/MetadataFactory.php
@@ -11,36 +11,43 @@ use Metadata\Driver\DriverInterface;
 class MetadataFactory implements AdvancedMetadataFactoryInterface
 {
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var DriverInterface
      */
     private $driver;
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var CacheInterface
      */
     private $cache;
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var ClassMetadata[]
      */
     private $loadedMetadata = [];
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var ClassMetadata[]
      */
     private $loadedClassMetadata = [];
 
     /**
-     * @var null|string
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
+     * @var string|null
      */
     private $hierarchyMetadataClass;
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var bool
      */
     private $includeInterfaces = false;
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var bool
      */
     private $debug = false;
@@ -62,7 +69,6 @@ class MetadataFactory implements AdvancedMetadataFactoryInterface
         $this->cache = $cache;
     }
 
-
     /**
      * {@inheritDoc}
      */
@@ -78,6 +84,7 @@ class MetadataFactory implements AdvancedMetadataFactoryInterface
                 if (null !== $classMetadata = $this->filterNullMetadata($this->loadedClassMetadata[$name])) {
                     $this->addClassMetadata($metadata, $classMetadata);
                 }
+
                 continue;
             }
 
@@ -193,6 +200,7 @@ class MetadataFactory implements AdvancedMetadataFactoryInterface
                 if (isset($addedInterfaces[$interface->getName()])) {
                     continue;
                 }
+
                 $addedInterfaces[$interface->getName()] = true;
 
                 $newHierarchy[] = $interface;
@@ -206,6 +214,7 @@ class MetadataFactory implements AdvancedMetadataFactoryInterface
 
     /**
      * @param ClassMetadata|ClassHierarchyMetadata|MergeableInterface $metadata
+     *
      * @return ClassMetadata|ClassHierarchyMetadata|MergeableInterface
      */
     private function filterNullMetadata($metadata = null)

--- a/src/MetadataFactoryInterface.php
+++ b/src/MetadataFactoryInterface.php
@@ -20,10 +20,10 @@ interface MetadataFactoryInterface
      *
      * If no metadata is available, null is returned.
      *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     *
      * @return ClassHierarchyMetadata|MergeableClassMetadata|null
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
      */
     public function getMetadataForClass(string $className);
 }

--- a/src/MethodMetadata.php
+++ b/src/MethodMetadata.php
@@ -16,19 +16,16 @@ namespace Metadata;
 class MethodMetadata implements \Serializable
 {
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     public $class;
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     public $name;
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var \ReflectionMethod
      */
     private $reflection;

--- a/src/MethodMetadata.php
+++ b/src/MethodMetadata.php
@@ -11,22 +11,24 @@ namespace Metadata;
  * properties, and flags.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
- *
  * @property $reflection
  */
 class MethodMetadata implements \Serializable
 {
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     public $class;
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     public $name;
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var \ReflectionMethod
      */
     private $reflection;
@@ -48,11 +50,11 @@ class MethodMetadata implements \Serializable
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     *
      * @return string
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
      */
     public function serialize()
     {
@@ -60,16 +62,17 @@ class MethodMetadata implements \Serializable
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     *
      * @param string $str
+     *
      * @return void
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
      */
     public function unserialize($str)
     {
-        list($this->class, $this->name) = unserialize($str);
+        [$this->class, $this->name] = unserialize($str);
     }
 
     /**

--- a/src/PropertyMetadata.php
+++ b/src/PropertyMetadata.php
@@ -15,13 +15,11 @@ namespace Metadata;
 class PropertyMetadata implements \Serializable
 {
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     public $class;
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     public $name;

--- a/src/PropertyMetadata.php
+++ b/src/PropertyMetadata.php
@@ -15,11 +15,13 @@ namespace Metadata;
 class PropertyMetadata implements \Serializable
 {
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     public $class;
 
     /**
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint
      * @var string
      */
     public $name;
@@ -31,11 +33,11 @@ class PropertyMetadata implements \Serializable
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     *
      * @return string
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
      */
     public function serialize()
     {
@@ -46,15 +48,16 @@ class PropertyMetadata implements \Serializable
     }
 
     /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingReturnTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     *
      * @param string $str
+     *
      * @return void
+     *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
      */
     public function unserialize($str)
     {
-        list($this->class, $this->name) = unserialize($str);
+        [$this->class, $this->name] = unserialize($str);
     }
 }

--- a/tests/Cache/DoctrineCacheAdapterTest.php
+++ b/tests/Cache/DoctrineCacheAdapterTest.php
@@ -23,8 +23,9 @@ class DoctrineCacheAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
      * @param string $className
+     *
+     * @dataProvider classNameProvider
      */
     public function testLoadEvictPutClassMetadataFromInCache(string $className)
     {

--- a/tests/Cache/DoctrineCacheAdapterTest.php
+++ b/tests/Cache/DoctrineCacheAdapterTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 class DoctrineCacheAdapterTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!interface_exists('Doctrine\Common\Cache\Cache')) {
             $this->markTestSkipped('Doctrine\Common is not installed.');

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -24,8 +24,9 @@ class FileCacheTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
      * @param string $className
+     *
+     * @dataProvider classNameProvider
      */
     public function testLoadEvictPutClassMetadataFromInCache(string $className)
     {

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -13,7 +13,7 @@ class FileCacheTest extends TestCase
 {
     private $dir;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->dir = sys_get_temp_dir() . '/jms-' . md5(__CLASS__);
         if (is_dir($this->dir)) {

--- a/tests/Cache/PsrCacheAdapterTest.php
+++ b/tests/Cache/PsrCacheAdapterTest.php
@@ -24,8 +24,9 @@ class PsrCacheAdapterTest extends TestCase
     }
 
     /**
-     * @dataProvider classNameProvider
      * @param string $className
+     *
+     * @dataProvider classNameProvider
      */
     public function testLoadEvictPutClassMetadataFromInCache(string $className)
     {

--- a/tests/Cache/PsrCacheAdapterTest.php
+++ b/tests/Cache/PsrCacheAdapterTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Cache\CacheItem;
  */
 class PsrCacheAdapterTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         if (!class_exists(CacheItem::class)) {
             $this->markTestSkipped('symfony/cache is not installed.');

--- a/tests/Driver/AbstractFileDriverTest.php
+++ b/tests/Driver/AbstractFileDriverTest.php
@@ -23,7 +23,7 @@ class AbstractFileDriverTest extends TestCase
     /** @var \PHPUnit_Framework_MockObject_MockObject */
     private $driver;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->locator = $this->createMock(FileLocator::class, [], [], '', false);
         $this->driver = $this->getMockBuilder(AbstractFileDriver::class)

--- a/tests/Driver/DriverChainTest.php
+++ b/tests/Driver/DriverChainTest.php
@@ -18,8 +18,7 @@ class DriverChainTest extends TestCase
         $driver
             ->expects($this->once())
             ->method('loadMetadataForClass')
-            ->will($this->returnValue($metadata = new ClassMetadata(\stdClass::class)))
-        ;
+            ->will($this->returnValue($metadata = new ClassMetadata(\stdClass::class)));
         $chain = new DriverChain([$driver]);
 
         $this->assertSame($metadata, $chain->loadMetadataForClass(new \ReflectionClass(\stdClass::class)));
@@ -53,8 +52,7 @@ class DriverChainTest extends TestCase
         $driver
             ->expects($this->once())
             ->method('loadMetadataForClass')
-            ->will($this->returnValue(null))
-        ;
+            ->will($this->returnValue(null));
         new DriverChain([$driver]);
         $this->assertNull($driver->loadMetadataForClass(new \ReflectionClass(\stdClass::class)));
     }

--- a/tests/MetadataFactoryTest.php
+++ b/tests/MetadataFactoryTest.php
@@ -27,19 +27,16 @@ class MetadataFactoryTest extends TestCase
         $driver = $this->createMock(DriverInterface::class);
 
         $driver
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(TestObject::class)))
-            ->will($this->returnCallback(static function ($class) {
-                return new ClassMetadata($class->getName());
-            }));
-        $driver
-            ->expects($this->at(1))
-            ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(TestParent::class)))
-            ->will($this->returnCallback(static function ($class) {
-                return new ClassMetadata($class->getName());
-            }));
+            ->withConsecutive(
+                [$this->equalTo(new \ReflectionClass(TestObject::class))],
+                [$this->equalTo(new \ReflectionClass(TestParent::class))]
+            )
+            ->will($this->onConsecutiveCalls(
+                new ClassMetadata(TestObject::class),
+                new ClassMetadata(TestParent::class)
+            ));
 
         $factory = new MetadataFactory($driver);
         $metadata = $factory->getMetadataForClass(TestParent::class);
@@ -53,19 +50,16 @@ class MetadataFactoryTest extends TestCase
         $driver = $this->createMock(DriverInterface::class);
 
         $driver
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(TestObject::class)))
-            ->will($this->returnCallback(static function ($class) {
-                return new MergeableClassMetadata($class->getName());
-            }));
-        $driver
-            ->expects($this->at(1))
-            ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(TestParent::class)))
-            ->will($this->returnCallback(static function ($class) {
-                return new MergeableClassMetadata($class->getName());
-            }));
+            ->withConsecutive(
+                [$this->equalTo(new \ReflectionClass(TestObject::class))],
+                [$this->equalTo(new \ReflectionClass(TestParent::class))]
+            )
+            ->will($this->onConsecutiveCalls(
+                new MergeableClassMetadata(TestObject::class),
+                new MergeableClassMetadata(TestParent::class)
+            ));
 
         $factory = new MetadataFactory($driver);
         $metadata = $factory->getMetadataForClass(TestParent::class);
@@ -160,21 +154,14 @@ class MetadataFactoryTest extends TestCase
         $driver = $this->createMock(DriverInterface::class);
 
         $driver
-            ->expects($this->at(3))
+            ->expects($this->exactly(4))
             ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(SubClassA::class)));
-        $driver
-            ->expects($this->at(2))
-            ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(InterfaceB::class)));
-        $driver
-            ->expects($this->at(1))
-            ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(BaseClass::class)));
-        $driver
-            ->expects($this->at(0))
-            ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(InterfaceA::class)));
+            ->withConsecutive(
+                [$this->equalTo(new \ReflectionClass(InterfaceA::class))],
+                [$this->equalTo(new \ReflectionClass(BaseClass::class))],
+                [$this->equalTo(new \ReflectionClass(InterfaceB::class))],
+                [$this->equalTo(new \ReflectionClass(SubClassA::class))]
+            );
 
         $factory = new MetadataFactory($driver);
         $factory->setIncludeInterfaces(true);

--- a/tests/MetadataFactoryTest.php
+++ b/tests/MetadataFactoryTest.php
@@ -30,18 +30,16 @@ class MetadataFactoryTest extends TestCase
             ->expects($this->at(0))
             ->method('loadMetadataForClass')
             ->with($this->equalTo(new \ReflectionClass(TestObject::class)))
-            ->will($this->returnCallback(function ($class) {
+            ->will($this->returnCallback(static function ($class) {
                 return new ClassMetadata($class->getName());
-            }))
-        ;
+            }));
         $driver
             ->expects($this->at(1))
             ->method('loadMetadataForClass')
             ->with($this->equalTo(new \ReflectionClass(TestParent::class)))
-            ->will($this->returnCallback(function ($class) {
+            ->will($this->returnCallback(static function ($class) {
                 return new ClassMetadata($class->getName());
-            }))
-        ;
+            }));
 
         $factory = new MetadataFactory($driver);
         $metadata = $factory->getMetadataForClass(TestParent::class);
@@ -58,18 +56,16 @@ class MetadataFactoryTest extends TestCase
             ->expects($this->at(0))
             ->method('loadMetadataForClass')
             ->with($this->equalTo(new \ReflectionClass(TestObject::class)))
-            ->will($this->returnCallback(function ($class) {
+            ->will($this->returnCallback(static function ($class) {
                 return new MergeableClassMetadata($class->getName());
-            }))
-        ;
+            }));
         $driver
             ->expects($this->at(1))
             ->method('loadMetadataForClass')
             ->with($this->equalTo(new \ReflectionClass(TestParent::class)))
-            ->will($this->returnCallback(function ($class) {
+            ->will($this->returnCallback(static function ($class) {
                 return new MergeableClassMetadata($class->getName());
-            }))
-        ;
+            }));
 
         $factory = new MetadataFactory($driver);
         $metadata = $factory->getMetadataForClass(TestParent::class);
@@ -85,7 +81,7 @@ class MetadataFactoryTest extends TestCase
         $driver
             ->expects($this->any())
             ->method('loadMetadataForClass')
-            ->will($this->returnCallback(function ($class) {
+            ->will($this->returnCallback(static function ($class) {
                 $metadata = new MergeableClassMetadata($class->name);
 
                 switch ($class->name) {
@@ -106,8 +102,7 @@ class MetadataFactoryTest extends TestCase
                 }
 
                 return $metadata;
-            }))
-        ;
+            }));
 
         $factory = new MetadataFactory($driver);
 
@@ -126,8 +121,7 @@ class MetadataFactoryTest extends TestCase
         $driver
             ->expects($this->once())
             ->method('loadMetadataForClass')
-            ->will($this->returnValue($metadata = new ClassMetadata(TestObject::class)))
-        ;
+            ->will($this->returnValue($metadata = new ClassMetadata(TestObject::class)));
 
         $factory = new MetadataFactory($driver);
 
@@ -136,13 +130,11 @@ class MetadataFactoryTest extends TestCase
             ->expects($this->once())
             ->method('load')
             ->with($this->equalTo(TestObject::class))
-            ->will($this->returnValue(null))
-        ;
+            ->will($this->returnValue(null));
         $cache
             ->expects($this->once())
             ->method('put')
-            ->with($this->equalTo($metadata))
-        ;
+            ->with($this->equalTo($metadata));
         $factory->setCache($cache);
 
         $factory->getMetadataForClass(TestObject::class);
@@ -156,8 +148,7 @@ class MetadataFactoryTest extends TestCase
         $driver
             ->expects($this->once())
             ->method('loadMetadataForClass')
-            ->will($this->returnValue(null))
-        ;
+            ->will($this->returnValue(null));
 
         $factory = new MetadataFactory($driver);
 
@@ -171,23 +162,19 @@ class MetadataFactoryTest extends TestCase
         $driver
             ->expects($this->at(3))
             ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(SubClassA::class)))
-        ;
+            ->with($this->equalTo(new \ReflectionClass(SubClassA::class)));
         $driver
             ->expects($this->at(2))
             ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(InterfaceB::class)))
-        ;
+            ->with($this->equalTo(new \ReflectionClass(InterfaceB::class)));
         $driver
             ->expects($this->at(1))
             ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(BaseClass::class)))
-        ;
+            ->with($this->equalTo(new \ReflectionClass(BaseClass::class)));
         $driver
             ->expects($this->at(0))
             ->method('loadMetadataForClass')
-            ->with($this->equalTo(new \ReflectionClass(InterfaceA::class)))
-        ;
+            ->with($this->equalTo(new \ReflectionClass(InterfaceA::class)));
 
         $factory = new MetadataFactory($driver);
         $factory->setIncludeInterfaces(true);
@@ -220,8 +207,7 @@ class MetadataFactoryTest extends TestCase
         $driver
             ->expects($this->once()) // This is the important part of this test
             ->method('loadMetadataForClass')
-            ->will($this->returnValue(null))
-        ;
+            ->will($this->returnValue(null));
 
         $cachedMetadata = null;
         $cache = $this->createMock(CacheInterface::class);
@@ -229,17 +215,15 @@ class MetadataFactoryTest extends TestCase
             ->expects($this->any())
             ->method('load')
             ->with($this->equalTo(TestObject::class))
-            ->will($this->returnCallback(function () use (&$cachedMetadata) {
+            ->will($this->returnCallback(static function () use (&$cachedMetadata) {
                 return $cachedMetadata;
-            }))
-        ;
+            }));
         $cache
             ->expects($this->once())
             ->method('put')
-            ->will($this->returnCallback(function ($metadata) use (&$cachedMetadata) {
+            ->will($this->returnCallback(static function ($metadata) use (&$cachedMetadata) {
                 $cachedMetadata = $metadata;
-            }))
-        ;
+            }));
 
         $factory = new MetadataFactory($driver);
         $factory->setCache($cache);
@@ -261,20 +245,17 @@ class MetadataFactoryTest extends TestCase
         $driver
             ->expects($this->exactly(2))
             ->method('loadMetadataForClass')
-            ->will($this->returnValue(null))
-        ;
+            ->will($this->returnValue(null));
 
         $cache = $this->createMock(CacheInterface::class);
         $cache
             ->expects($this->any())
             ->method('load')
             ->with($this->equalTo(TestObject::class))
-            ->will($this->returnValue(null))
-        ;
+            ->will($this->returnValue(null));
         $cache
             ->expects($this->never())
-            ->method('put')
-        ;
+            ->method('put');
 
         $factory = new MetadataFactory($driver, ClassHierarchyMetadata::class, true);
         $factory->setCache($cache);

--- a/tests/MethodMetadataTest.php
+++ b/tests/MethodMetadataTest.php
@@ -6,7 +6,6 @@ namespace Metadata\Tests;
 
 use Metadata\MethodMetadata;
 use Metadata\Tests\Fixtures\TestObject;
-use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\TestCase;
 
 class MethodMetadataTest extends TestCase
@@ -85,7 +84,12 @@ class MethodMetadataTest extends TestCase
     {
         $metadata = new MethodMetadata(TestObject::class, 'setFoo');
 
-        $this->expectException(Notice::class);
+        if (version_compare(PHP_VERSION, '8.0.0-dev', '>=')) {
+            $this->expectWarning();
+        } else {
+            $this->expectNotice();
+        }
+
         $this->expectExceptionMessage('Undefined property: Metadata\MethodMetadata::$unknownProperty');
 
         $metadata->unknownProperty;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes (except phpcs for PHP nightly)
| Fixed tickets | 
| License       | MIT

* bump `doctrine/coding-standard`
* bump `phpunit/phpunit`
* test against PHP 8 (phpcs failure seems to be related to squizlabs/PHP_CodeSniffer#3140 and will hopefully be fixed after the next release of squizlabs/php_codesniffer)