### PR TITLE
Automatically create cache directory when missing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "phpunit/phpunit": "^8.5|^9.0",
         "psr/container": "^1.0",
         "symfony/cache" : "^3.1|^4.0|^5.0",
-        "symfony/dependency-injection" : "^3.1|^4.0|^5.0"
+        "symfony/dependency-injection" : "^3.1|^4.0|^5.0",
+        "mikey179/vfsstream": "^1.6.7"
     },
     "autoload": {
         "psr-4": { "Metadata\\": "src/" }

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -24,7 +24,7 @@ class FileCache implements CacheInterface
 
     public function load(string $class): ?ClassMetadata
     {
-        $path = $this->dir . '/' . $this->sanitizeCacheKey($class) . '.cache.php';
+        $path = $this->getCachePath($class);
         if (!file_exists($path)) {
             return null;
         }
@@ -49,7 +49,7 @@ class FileCache implements CacheInterface
             throw new \InvalidArgumentException(sprintf('The directory "%s" is not writable.', $this->dir));
         }
 
-        $path = $this->dir . '/' . $this->sanitizeCacheKey($metadata->name) . '.cache.php';
+        $path = $this->getCachePath($metadata->name);
 
         $tmpFile = tempnam($this->dir, 'metadata-cache');
         if (false === $tmpFile) {
@@ -97,18 +97,22 @@ class FileCache implements CacheInterface
 
     public function evict(string $class): void
     {
-        $path = $this->dir . '/' . $this->sanitizeCacheKey($class) . '.cache.php';
+        $path = $this->getCachePath($class);
         if (file_exists($path)) {
             @unlink($path);
         }
     }
 
     /**
+     * This function computes the cache file path.
+     *
      * If anonymous class is to be cached, it contains invalid path characters that need to be removed/replaced
      * Example of anonymous class name: class@anonymous\x00/app/src/Controller/DefaultController.php0x7f82a7e026ec
      */
-    private function sanitizeCacheKey(string $key): string
+    private function getCachePath(string $key): string
     {
-        return str_replace(['\\', "\0", '@', '/', '$', '{', '}', ':'], '-', $key);
+        $fileName = str_replace(['\\', "\0", '@', '/', '$', '{', '}', ':'], '-', $key);
+
+        return $this->dir . '/' . $fileName . '.cache.php';
     }
 }

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -15,8 +15,8 @@ class FileCache implements CacheInterface
 
     public function __construct(string $dir)
     {
-        if (!is_dir($dir)) {
-            throw new \InvalidArgumentException(sprintf('The directory "%s" does not exist.', $dir));
+        if (!is_dir($dir) && false === @mkdir($dir, 0777, true)) {
+            throw new \InvalidArgumentException(sprintf('Can\'t create directory for cache at "%s"', $dir));
         }
 
         $this->dir = rtrim($dir, '\\/');
@@ -50,6 +50,9 @@ class FileCache implements CacheInterface
         }
 
         $path = $this->getCachePath($metadata->name);
+        if (!is_writable(dirname($path))) {
+            throw new \RuntimeException(sprintf('Cache file "%s" is not writable.', $path));
+        }
 
         $tmpFile = tempnam($this->dir, 'metadata-cache');
         if (false === $tmpFile) {

--- a/tests/Cache/FileCacheTest.php
+++ b/tests/Cache/FileCacheTest.php
@@ -7,16 +7,24 @@ namespace Metadata\Tests\Cache;
 use Metadata\Cache\FileCache;
 use Metadata\ClassMetadata;
 use Metadata\Tests\Fixtures\TestObject;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
 
 class FileCacheTest extends TestCase
 {
     private $dir;
+    private $nestedDir;
 
     protected function setUp(): void
     {
         $this->dir = sys_get_temp_dir() . '/jms-' . md5(__CLASS__);
+        $this->nestedDir = $this->dir . '/some-dir';
         if (is_dir($this->dir)) {
+            if (is_dir($this->nestedDir)) {
+                array_map('unlink', glob($this->nestedDir . '/*'));
+                rmdir($this->nestedDir);
+            }
+
             array_map('unlink', glob($this->dir . '/*'));
         } else {
             mkdir($this->dir);
@@ -68,5 +76,34 @@ class FileCacheTest extends TestCase
         file_put_contents($this->dir . '/Metadata-Tests-Fixtures-TestObject.cache.php', $fileContents);
 
         $this->assertNull($cache->load(TestObject::class));
+    }
+
+    public function testPutCacheFileInNotExistingDirectory()
+    {
+        $cache = new FileCache($this->nestedDir);
+
+        $reflectionClass = new \ReflectionClass('Metadata\Tests\Fixtures\TestObject');
+        $cache->put($metadata = new ClassMetadata('Metadata\Tests\Fixtures\TestObject'));
+        $this->assertEquals($metadata, $cache->load($reflectionClass->name));
+    }
+
+    public function testThrowExceptionIfCacheDirNotWritable()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Can\'t create directory for cache at "vfs://root/JMS"');
+
+        $root = vfsStream::setup('root', 0555);
+        $cache = new FileCache($root->url() . '/JMS');
+    }
+
+    public function testThrowExceptionIfCacheFilePathNotWritable()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The directory "vfs://root" is not writable.');
+
+        $root = vfsStream::setup('root', 0555);
+        $cache = new FileCache($root->url());
+
+        $cache->put($metadata = new ClassMetadata('Metadata\Tests\Fixtures\TestParent'));
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | #62 <!-- #-prefixed issue number(s), if any -->
| License       | MIT


This is a heavily rebased/adjusted version of the PR as proposed by @brzuchal in #62.

With this change, the `FileCache` no longer fails when the cache directory doesn't exist on instantiation, instead it creates it when possible. If creation is not possible, it will still throw an exception.
