### PR TITLE
load cache issue in high concurrency situations 

### DIFF
--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -25,7 +25,7 @@ class FileCache implements CacheInterface, ClearableCacheInterface
     public function load(string $class): ?ClassMetadata
     {
         $path = $this->getCachePath($class);
-        if (!file_exists($path)) {
+        if (!is_readable($path)) {
             return null;
         }
 
@@ -35,7 +35,7 @@ class FileCache implements CacheInterface, ClearableCacheInterface
                 return $metadata;
             }
             // if the file does not return anything, the return value is integer `1`.
-        } catch (\ParseError $e) {
+        } catch (\Error $e) {
             // ignore corrupted cache
         }
 


### PR DESCRIPTION
in high concurrency situations, with slow filesystems one request might delete (try to refresh) the cache entry after the file_exists check passed.

this will result in a file not found error when including the file. to avoid such situations we ignore this type of errors



