### PR TITLE
Remove checks for Symfony's DI Container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "phpunit/phpunit": "^8.5|^9.0",
         "psr/container": "^1.0",
         "symfony/cache" : "^3.1|^4.0|^5.0",
-        "symfony/dependency-injection" : "^3.1|^4.0|^5.0",
         "mikey179/vfsstream": "^1.6.7"
     },
     "autoload": {

--- a/src/Driver/LazyLoadingDriver.php
+++ b/src/Driver/LazyLoadingDriver.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Metadata\Driver;
 
 use Metadata\ClassMetadata;
-use Psr\Container\ContainerInterface as PsrContainerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 class LazyLoadingDriver implements DriverInterface
 {
     /**
-     * @var ContainerInterface|PsrContainerInterface
+     * @var ContainerInterface
      */
     private $container;
 
@@ -21,12 +20,12 @@ class LazyLoadingDriver implements DriverInterface
     private $realDriverId;
 
     /**
-     * @param ContainerInterface|PsrContainerInterface $container
+     * @param ContainerInterface $container
      */
     public function __construct($container, string $realDriverId)
     {
-        if (!$container instanceof PsrContainerInterface && !$container instanceof ContainerInterface) {
-            throw new \InvalidArgumentException(sprintf('The container must be an instance of %s or %s (%s given).', PsrContainerInterface::class, ContainerInterface::class, \is_object($container) ? \get_class($container) : \gettype($container)));
+        if (!$container instanceof ContainerInterface) {
+            throw new \InvalidArgumentException(sprintf('The container must be an instance of %s (%s given).', ContainerInterface::class, \is_object($container) ? \get_class($container) : \gettype($container)));
         }
 
         $this->container = $container;

--- a/tests/Driver/LazyLoadingDriverTest.php
+++ b/tests/Driver/LazyLoadingDriverTest.php
@@ -10,7 +10,6 @@ use Metadata\Driver\LazyLoadingDriver;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\DependencyInjection\Container;
 
 class LazyLoadingDriverTest extends TestCase
 {
@@ -35,22 +34,6 @@ class LazyLoadingDriverTest extends TestCase
         $this->ref = new \ReflectionClass(\stdClass::class);
 
         $this->realDriver = $this->createMock(DriverInterface::class);
-    }
-
-    public function testSymfonyContainer()
-    {
-        $this->realDriver
-            ->expects($this->once())
-            ->method('loadMetadataForClass')
-            ->with($this->ref)
-            ->willReturn($this->metadata);
-
-        $container = new Container();
-        $container->set('foo', $this->realDriver);
-
-        $driver = new LazyLoadingDriver($container, 'foo');
-
-        self::assertSame($this->metadata, $driver->loadMetadataForClass($this->ref));
     }
 
     public function testPsrContainer()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

Since Symfony 3.3, the DI component's `ContainerInterface` has extended the PSR-11 `ContainerInterface`.  So unless Symfony 3.2 and older are still being supported here, there isn't a need to explicitly check for the Symfony container in the lazy driver.