### PR TITLE
Fix compatibility with PHP 8.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,6 +16,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
     steps:
     - uses: actions/checkout@v2
     - name: Validate composer.json and composer.lock
@@ -46,6 +47,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
     steps:
       - uses: actions/checkout@v2
 

--- a/src/Cache/FileCache.php
+++ b/src/Cache/FileCache.php
@@ -34,6 +34,7 @@ class FileCache implements CacheInterface, ClearableCacheInterface
             if ($metadata instanceof ClassMetadata) {
                 return $metadata;
             }
+
             // if the file does not return anything, the return value is integer `1`.
         } catch (\Error $e) {
             // ignore corrupted cache

--- a/src/ClassMetadata.php
+++ b/src/ClassMetadata.php
@@ -82,13 +82,7 @@ class ClassMetadata implements \Serializable
      */
     public function serialize()
     {
-        return serialize([
-            $this->name,
-            $this->methodMetadata,
-            $this->propertyMetadata,
-            $this->fileResources,
-            $this->createdAt,
-        ]);
+        return serialize($this->__serialize());
     }
 
     /**
@@ -102,12 +96,34 @@ class ClassMetadata implements \Serializable
      */
     public function unserialize($str)
     {
+        $this->__unserialize((array) unserialize((string) $str));
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function __serialize(): array
+    {
+        return [
+            $this->name,
+            $this->methodMetadata,
+            $this->propertyMetadata,
+            $this->fileResources,
+            $this->createdAt,
+        ];
+    }
+
+    /**
+     * @param array<mixed> $data
+     */
+    public function __unserialize(array $data): void
+    {
         [
             $this->name,
             $this->methodMetadata,
             $this->propertyMetadata,
             $this->fileResources,
             $this->createdAt,
-        ] = unserialize($str);
+        ] = $data;
     }
 }

--- a/src/MethodMetadata.php
+++ b/src/MethodMetadata.php
@@ -55,7 +55,7 @@ class MethodMetadata implements \Serializable
      */
     public function serialize()
     {
-        return serialize([$this->class, $this->name]);
+        return serialize($this->__serialize());
     }
 
     /**
@@ -69,7 +69,23 @@ class MethodMetadata implements \Serializable
      */
     public function unserialize($str)
     {
-        [$this->class, $this->name] = unserialize($str);
+        $this->__unserialize((array) unserialize((string) $str));
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function __serialize(): array
+    {
+        return [$this->class, $this->name];
+    }
+
+    /**
+     * @param array<string> $data
+     */
+    public function __unserialize(array $data): void
+    {
+        [$this->class, $this->name] = $data;
     }
 
     /**

--- a/src/PropertyMetadata.php
+++ b/src/PropertyMetadata.php
@@ -39,10 +39,7 @@ class PropertyMetadata implements \Serializable
      */
     public function serialize()
     {
-        return serialize([
-            $this->class,
-            $this->name,
-        ]);
+        return serialize($this->__serialize());
     }
 
     /**
@@ -56,6 +53,25 @@ class PropertyMetadata implements \Serializable
      */
     public function unserialize($str)
     {
-        [$this->class, $this->name] = unserialize($str);
+        $this->__unserialize((array) unserialize((string) $str));
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function __serialize(): array
+    {
+        return [
+            $this->class,
+            $this->name,
+        ];
+    }
+
+    /**
+     * @param array<string> $data
+     */
+    public function __unserialize(array $data): void
+    {
+        [$this->class, $this->name] = $data;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Run tests against PHP 8.1 and fix deprecation warning because of deprecated Serializeable interface (https://wiki.php.net/rfc/phase_out_serializable)