### PR TITLE
Handle current master as new major version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-master": "3.x-dev"
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

As it seems we need todo a new major version, I updated the composer.json so current `composer update` with `^2.0@dev` will not install it: https://github.com/schmittjoh/metadata/pull/101#issuecomment-957918814