### PR TITLE
Allows backward compatible support for the new __serialize and __unserialize methods

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,55 @@
+From 2.2.3 to 2.3.0
+====================
+
+- The `\Serializable` PHP interface is deprecated, the methods of this interface will be removed in 3.0.
+  This change is done to allow the use of the new `__serialize` and `__unserialize` PHP's strategy.
+
+  If you were extending the metadata classes, your custom serialization methods were looking probably as something as this:
+
+    ```php
+    class MyMetadata extends PropertyMetadata 
+    {
+        // ... more code
+        
+        public function serialize()
+        {
+            $data = parent::serialize();
+    
+            return \serialize([$data, $this->customMetadataProp]);
+        }
+    
+        public function unserialize($str)
+        {
+            list($str, $this->customMetadataProp) = \unserialize($str);
+    
+            parent::unserialize($str);
+        }
+    }
+    ```
+    
+    After this change, your code should look like this:
+    
+    ```php
+    class MyMetadata extends PropertyMetadata 
+    {
+        // ... more code
+        
+        protected function serializeToArray(): array
+        {
+            $data = parent::serializeToArray();
+    
+            return [$data, $this->customMetadataProp];
+        }
+    
+        protected function unserializeFromArray(array $data): void
+        {
+            list($data, $this->customMetadataProp) = $data;
+    
+            parent::unserializeFromArray($data);
+        }
+    }
+    ```
+
 From 1.7.0 to 2.0.0
 ====================
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -31,6 +31,29 @@
 
     </rule>
 
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification">
+        <exclude-pattern>src/PropertyMetadata.php</exclude-pattern>
+        <exclude-pattern>src/MethodMetadata.php</exclude-pattern>
+        <exclude-pattern>src/ClassMetadata.php</exclude-pattern>
+        <exclude-pattern>src/SerializationHelper.php</exclude-pattern>
+    </rule>
+
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification">
+        <exclude-pattern>src/PropertyMetadata.php</exclude-pattern>
+        <exclude-pattern>src/MethodMetadata.php</exclude-pattern>
+        <exclude-pattern>src/ClassMetadata.php</exclude-pattern>
+        <exclude-pattern>src/SerializationHelper.php</exclude-pattern>
+    </rule>
+
+
+    <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint">
+        <exclude-pattern>src/SerializationHelper.php</exclude-pattern>
+    </rule>
+    <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint">
+        <exclude-pattern>src/SerializationHelper.php</exclude-pattern>
+    </rule>
+
+
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireYodaComparison"/>
 
      <rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations">

--- a/src/ClassMetadata.php
+++ b/src/ClassMetadata.php
@@ -14,6 +14,8 @@ namespace Metadata;
  */
 class ClassMetadata implements \Serializable
 {
+    use SerializationHelper;
+
     /**
      * @var string
      */
@@ -74,33 +76,18 @@ class ClassMetadata implements \Serializable
         return true;
     }
 
-    /**
-     * @return string
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     */
-    public function serialize()
+    protected function serializeToArray(): array
     {
-        return serialize([
+        return [
             $this->name,
             $this->methodMetadata,
             $this->propertyMetadata,
             $this->fileResources,
             $this->createdAt,
-        ]);
+        ];
     }
 
-    /**
-     * @param string $str
-     *
-     * @return void
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     */
-    public function unserialize($str)
+    protected function unserializeFromArray(array $data): void
     {
         [
             $this->name,
@@ -108,22 +95,6 @@ class ClassMetadata implements \Serializable
             $this->propertyMetadata,
             $this->fileResources,
             $this->createdAt,
-        ] = unserialize($str);
-    }
-
-    /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification
-     */
-    public function __serialize(): array
-    {
-        return [$this->serialize()];
-    }
-
-    /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
-     */
-    public function __unserialize(array $data): void
-    {
-        $this->unserialize($data[0]);
+        ] = $data;
     }
 }

--- a/src/MethodMetadata.php
+++ b/src/MethodMetadata.php
@@ -15,6 +15,8 @@ namespace Metadata;
  */
 class MethodMetadata implements \Serializable
 {
+    use SerializationHelper;
+
     /**
      * @var string
      */
@@ -47,48 +49,6 @@ class MethodMetadata implements \Serializable
     }
 
     /**
-     * @return string
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     */
-    public function serialize()
-    {
-        return serialize([$this->class, $this->name]);
-    }
-
-    /**
-     * @param string $str
-     *
-     * @return void
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     */
-    public function unserialize($str)
-    {
-        [$this->class, $this->name] = unserialize($str);
-    }
-
-    /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification
-     */
-    public function __serialize(): array
-    {
-        return [$this->serialize()];
-    }
-
-    /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
-     */
-    public function __unserialize(array $data): void
-    {
-        $this->unserialize($data[0]);
-    }
-
-    /**
      * @return mixed
      */
     public function __get(string $propertyName)
@@ -116,5 +76,15 @@ class MethodMetadata implements \Serializable
         }
 
         return $this->reflection;
+    }
+
+    protected function serializeToArray(): array
+    {
+        return [$this->class, $this->name];
+    }
+
+    protected function unserializeFromArray(array $data): void
+    {
+        [$this->class, $this->name] = $data;
     }
 }

--- a/src/PropertyMetadata.php
+++ b/src/PropertyMetadata.php
@@ -14,6 +14,8 @@ namespace Metadata;
  */
 class PropertyMetadata implements \Serializable
 {
+    use SerializationHelper;
+
     /**
      * @var string
      */
@@ -30,48 +32,16 @@ class PropertyMetadata implements \Serializable
         $this->name = $name;
     }
 
-    /**
-     * @return string
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     */
-    public function serialize()
+    protected function serializeToArray(): array
     {
-        return serialize([
+        return [
             $this->class,
             $this->name,
-        ]);
+        ];
     }
 
-    /**
-     * @param string $str
-     *
-     * @return void
-     *
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.UselessReturnAnnotation
-     */
-    public function unserialize($str)
+    protected function unserializeFromArray(array $data): void
     {
-        [$this->class, $this->name] = unserialize($str);
-    }
-
-    /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingTraversableTypeHintSpecification
-     */
-    public function __serialize(): array
-    {
-        return [$this->serialize()];
-    }
-
-    /**
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingTraversableTypeHintSpecification
-     */
-    public function __unserialize(array $data): void
-    {
-        $this->unserialize($data[0]);
+        [$this->class, $this->name] = $data;
     }
 }

--- a/src/SerializationHelper.php
+++ b/src/SerializationHelper.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Metadata;
+
+trait SerializationHelper
+{
+    /**
+     * @deprecated Use serializeToArray
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        return serialize($this->serializeToArray());
+    }
+
+    /**
+     * @deprecated Use unserializeFromArray
+     *
+     * @param string $str
+     *
+     * @return void
+     */
+    public function unserialize($str)
+    {
+        $this->unserializeFromArray(unserialize($str));
+    }
+
+    public function __serialize(): array
+    {
+        return $this->serializeToArray();
+    }
+
+    public function __unserialize(array $data): void
+    {
+        $this->unserializeFromArray($data);
+    }
+}


### PR DESCRIPTION
Allows backward compatible support for the new __serialize and __unserialize methods and  plan upgrade path to remove the \Serialize interface in 3.0.

This pull request introduces two new methods `serializeToArray` and `unserializeFromArray` to handle in a backward compatible way (php 8.1) the serialization process.



If you were extending the metadata classes, you custom serialization methods were looking probably as something as this:

```php
class MyMetadata extends PropertyMetadata 
{
    // ... more code
    public function serialize()
    {
        $data = parent::serialize();

        return \serialize([$data, $this->moreCustomMetadataProps]);
    }

    public function unserialize($data)
    {
        list($data, $this->moreCustomMetadataProps) = \unserialize($data);

        parent::unserialize($data);
    }
}
```


After this change, your code should look like this:

```php
class MyMetadata extends PropertyMetadata 
{
    // ... more code
    protected function serializeToArray():
    {
        $data = parent::serializeToArray(): array

        return [$data, $this->moreCustomMetadataProps];
    }

    protected function unserializeFromArray(array $data): void
    {
        list($data, $this->moreCustomMetadataProps) = $data;

        parent::unserializeFromArray($data);
    }
}
```

Note, this is something you should change only if you plan to upgrade to the upcoming 3.0 version of this package (and plan support for php 9).






