### PR TITLE
Allow psr/container 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/cache" : "^1.0",
         "doctrine/coding-standard": "^8.0",
         "phpunit/phpunit": "^8.5|^9.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0|^2.0",
         "symfony/cache" : "^3.1|^4.0|^5.0",
         "symfony/dependency-injection" : "^3.1|^4.0|^5.0",
         "mikey179/vfsstream": "^1.6.7"

--- a/tests/Driver/LazyLoadingDriverTest.php
+++ b/tests/Driver/LazyLoadingDriverTest.php
@@ -74,7 +74,7 @@ class LazyLoadingDriverTest extends TestCase
                 return $this->service;
             }
 
-            public function has($id)
+            public function has($id): bool
             {
                 return true;
             }


### PR DESCRIPTION
Should allow psr/container 2.0.2 - not only 1.1.2

Changes:
[php-fig/container@2.0.2...1.1.2
](https://github.com/php-fig/container/compare/2.0.2...1.1.2)
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no 
| Tests pass?   | yes
| License       | MIT

