### PR TITLE
Deprecate the Doctrine Cache integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.lock
 phpcs.xml
 .phpcs-cache
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.2|^8.0"
     },
     "require-dev" : {
-        "doctrine/cache" : "^1.0",
+        "doctrine/cache" : "^1.0|^2.0",
         "doctrine/coding-standard": "^8.0",
         "phpunit/phpunit": "^8.5|^9.0",
         "psr/container": "^1.0|^2.0",

--- a/src/Cache/DoctrineCacheAdapter.php
+++ b/src/Cache/DoctrineCacheAdapter.php
@@ -8,6 +8,8 @@ use Doctrine\Common\Cache\Cache;
 use Metadata\ClassMetadata;
 
 /**
+ * @deprecated use the {@see PsrCacheAdapter} instead
+ *
  * @author Henrik Bjornskov <henrik@bjrnskov.dk>
  */
 class DoctrineCacheAdapter implements CacheInterface, ClearableCacheInterface

--- a/tests/Cache/DoctrineCacheAdapterTest.php
+++ b/tests/Cache/DoctrineCacheAdapterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Metadata\Tests\Cache;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Cache;
 use Metadata\Cache\DoctrineCacheAdapter;
 use Metadata\ClassMetadata;
 use Metadata\Tests\Driver\Fixture\A\A;
@@ -12,15 +13,16 @@ use Metadata\Tests\Driver\Fixture\B\B;
 use Metadata\Tests\Fixtures\TestObject;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @requires PHP 5.4
- */
 class DoctrineCacheAdapterTest extends TestCase
 {
-    protected function setUp(): void
+    public static function setUpBeforeClass(): void
     {
-        if (!interface_exists('Doctrine\Common\Cache\Cache')) {
-            $this->markTestSkipped('Doctrine\Common is not installed.');
+        if (!interface_exists(Cache::class)) {
+            static::markTestSkipped('doctrine/cache is not installed.');
+        }
+
+        if (!class_exists(ArrayCache::class)) {
+            static::markTestSkipped('doctrine/cache >=2.0 is installed.');
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | N/A
| License       | MIT

The Doctrine Cache component is deprecated, with its 2.0 release only keeping the interfaces and a bridging layer to allow PSR-6 cache implementations to be used to fulfill the Doctrine Cache interfaces.  This integration should now be deprecated.