### PR TITLE
Do not call Reflection*::setAccessible() in PHP >= 8.1

### DIFF
--- a/src/MethodMetadata.php
+++ b/src/MethodMetadata.php
@@ -72,7 +72,9 @@ class MethodMetadata implements \Serializable
     {
         if (null === $this->reflection) {
             $this->reflection = new \ReflectionMethod($this->class, $this->name);
-            $this->reflection->setAccessible(true);
+            if (\PHP_VERSION_ID < 80100) {
+                $this->reflection->setAccessible(true);
+            }
         }
 
         return $this->reflection;

--- a/tests/MethodMetadataTest.php
+++ b/tests/MethodMetadataTest.php
@@ -14,7 +14,9 @@ class MethodMetadataTest extends TestCase
     {
         $metadata = new MethodMetadata(TestObject::class, 'setFoo');
         $expectedReflector = new \ReflectionMethod(TestObject::class, 'setFoo');
-        $expectedReflector->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $expectedReflector->setAccessible(true);
+        }
 
         $this->assertEquals(TestObject::class, $metadata->class);
         $this->assertEquals('setFoo', $metadata->name);
@@ -43,7 +45,9 @@ class MethodMetadataTest extends TestCase
         $metadata = new MethodMetadata(TestObject::class, 'setFoo');
 
         $reflectionProperty = new \ReflectionProperty(MethodMetadata::class, 'reflection');
-        $reflectionProperty->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
 
         $this->assertNull($reflectionProperty->getValue($metadata));
     }
@@ -54,7 +58,9 @@ class MethodMetadataTest extends TestCase
         unserialize(serialize($metadata));
 
         $reflectionProperty = new \ReflectionProperty(MethodMetadata::class, 'reflection');
-        $reflectionProperty->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
 
         $this->assertNull($reflectionProperty->getValue($metadata));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Doc updated   | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations