### PR TITLE
Change serialization and unserialization to use To/From Array methods

### DIFF
--- a/src/SerializationHelper.php
+++ b/src/SerializationHelper.php
@@ -30,11 +30,11 @@ trait SerializationHelper
 
     public function __serialize(): array
     {
-        return [$this->serialize()];
+        return $this->serializeToArray();
     }
 
     public function __unserialize(array $data): void
     {
-        $this->unserialize($data[0]);
+        $this->unserializeFromArray($data);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| Doc updated   | yes/no
| BC breaks?    | yes/no
| Deprecations? | yes/no 
| Tests pass?   | yes/no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->
| License       | MIT

When working with PHP 8.3.27, writing metadata cache triggers following PHP - error with Sulu:
"Error: Maximum call stack size reached. Infinite recursion?"

This exception does NOT trigger with PHP 8.3.26 since this change :  
https://github.com/php/php-src/issues/19701

This change fixes that. We also move away from deprecated code this way, so it seems a reasonable fix.
